### PR TITLE
Small badges fixs

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1289,7 +1289,7 @@
     },
     "planetarium": {
       "name": "Beyond the Stars",
-      "condition": "Enter the room in the Planetarium containing the Celestial effect"
+      "condition": "Enter the room in the Planetarium containing the Celestial alter"
     },
     "hospital_event": {
       "name": "Patient 001",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1289,7 +1289,7 @@
     },
     "planetarium": {
       "name": "Beyond the Stars",
-      "condition": "Enter the room in the Planetarium containing the Celestial effect"
+      "condition": "Enter the room in the Planetarium containing the Celestial alter"
     },
     "hospital_event": {
       "name": "Patient 001",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1289,7 +1289,7 @@
     },
     "planetarium": {
       "name": "Beyond the Stars",
-      "condition": "Enter the room in the Planetarium containing the Celestial effect"
+      "condition": "Enter the room in the Planetarium containing the Celestial alter"
     },
     "hospital_event": {
       "name": "Patient 001",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -545,7 +545,7 @@
     },
     "noranyan": {
       "name": "Noranyan",
-      "description": "Nyanyame nyanyajyuunyanya-do no nyarabi de nyakunyaku inyanyaku nyanyahan nyanyadai nyanynaku nyarabete nyaganyagame.",
+      "description": "Peux-tu imiawginer un gérant de miéwnagerie imiawginant miawnager une miéwnagerie imiawginaire.",
       "condition": "Interagir avec Noranyan dans la Sofa Room"
     },
     "cheese": {
@@ -900,7 +900,7 @@
     },
     "ice_cream": {
       "name": "Crème glacée au triple scoop",
-      "description": "Je me sens tout léger~",
+      "description": "Feeling like heaven~",
       "condition": "Arriver à l'Ice Cream Dream"
     },
     "five_guardians": {
@@ -1015,7 +1015,7 @@
     "clock_pole": {
       "name": "Ponctualité",
       "description": "Toujours être ponctuel!",
-      "condition": "Trouver et approcher les pôles d'horloges dans le Garden World (nuit), la Blue Forest, le Botanical Garden (2), le Sculpture Park, le Twilight Park et le Monochrome School"
+      "condition": "Trouver et approcher les pôles d'horloges dans le Garden World (nuit), la Blue Forest, le Botanical Garden (2), le Sculpture Park, le Twilight Park et la Monochrome School"
     },
     "coffee_cup": {
       "name": "Saveur du jour",
@@ -1047,7 +1047,7 @@
       "condition": "Voir le robot au Tesla Garden"
     },
     "green_prince": {
-      "name": "Touché coulé",
+      "name": "Touché!",
       "condition": "Atteindre et interagir avec le Prince Vert aux City Limits"
     },
     "phone": {
@@ -1238,10 +1238,10 @@
     },
     "koraiyn": {
       "name": "Koraiyn",
-      "description": "Qu'est-ce qu'un Koraiyn?"
+      "description": "Qu'est-ce qu'une Koraiyn?"
     },
     "missingno": {
-      "name": "Bug verdâtre",
+      "name": "MissingNo.",
       "condition": "Trouver et interagir avec MissingNo."
     },
     "halo": {
@@ -1289,7 +1289,7 @@
     },
     "planetarium": {
       "name": "Au-delà des étoiles",
-      "condition": "Entrer dans la salle dans le Planetarium contenant l'effet Celestial"
+      "condition": "Entrer dans la salle dans le Planetarium contenant l'alter Céleste"
     },
     "hospital_event": {
       "name": "Patient 001",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1289,7 +1289,7 @@
     },
     "planetarium": {
       "name": "Beyond the Stars",
-      "condition": "Enter the room in the Planetarium containing the Celestial effect"
+      "condition": "Enter the room in the Planetarium containing the Celestial alter"
     },
     "hospital_event": {
       "name": "Patient 001",


### PR DESCRIPTION
For the English, Deutsch, Spanish, French and Russian translation of the badge "Planetarium" of Deep Dreams, fixed the Celestial alter being listed as an effect.
For the French translation, several fixs:
- the condition of the "Planetarium" badge from Deep Dreams was modified to use the french name of the alter, and the effect was correctly renamed as an alter
- the condition of the "Punctuality" badge from 2kki was modified to be more correct, "le Monochrome School" is now "la Monochrome School"
- the description of the "Ice cream" badge from 2kki was edited to reflect the original intention of Cmax of not translating it in others languages (thanks Aya for pointing me this)
- the "MissingNo." badge's name from Answered Prayers was edited to now use this name like in the Japanese version, since the pun can't be translated in French
- the description of the "Koraiyn" badge from Answered Prayers was edited to match with the French translation of the game
- the "Green Prince" badge's name from 2kki was renamed to be more accurate to the English version
- the description of the "Noranyan" badge from 2kki was translated in French (thanks Zango for explaining me the reference)