### PR TITLE
Translated new badges added recently in French

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1192,7 +1192,7 @@
     },
     "infinite_library_mirror": {
       "name": "Désorientée",
-      "description": "Invoque ta réflection dans un miroir passé un semi-infini.",
+      "description": "Invoque ta réflection dans un miroir passé le semi-infini.",
       "condition": "Regarde-toi dans le miroir et atteindre Static Noise Hell depuis l'Infinite Library."
     }
   },

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1328,7 +1328,7 @@
     "lookout_point": {
       "name": "Point d'observation",
       "description": "Pas une gameboy en vue, juste des âmes profitant du moment.",
-      "condition": "Visiter la seconde île du Silhouette World par le Symbol Maze."
+      "condition": "Visiter la seconde île du Silhouette World par le Symbols Maze."
     },
     "phantom_symbols": {
       "name": "Symboles fantomatiques",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -684,7 +684,7 @@
       "condition": "Visiter le lointain paysage dans le Foliage Estate"
     },
     "sunken_city": {
-      "name": "Bâtiment inondée",
+      "name": "Bâtiment inondé",
       "condition": "Atteindre la Sunken City"
     },
     "crocodile_dog": {
@@ -1127,7 +1127,7 @@
     },
     "green_tea_cake": {
       "name": "Gâteau au thé vert",
-      "condition": "Acheter un gâteau au thé vert le la pâtisserie dans les Shop Ruins"
+      "condition": "Acheter un gâteau au thé vert de la pâtisserie dans les Shop Ruins"
     },
     "principal": {
       "name": "Pas de moto dans les couloirs!",
@@ -1166,34 +1166,34 @@
       "condition": "Entrer dans la salle à la fin de la route du Spirit Capital en {TIME} ou moins en course contre-la-montre"
     },
     "the_liar": {
-      "name": "Liar, Liar",
-      "description": "I know what you are.",
-      "condition": "Turn the light off in the Liar's bedroom."
+      "name": "Menteur, menteur",
+      "description": "Je sais ce que tu es.",
+      "condition": "Éteindre la lumière dans la Liar's bedroom."
     },
     "the_assistant": {
-      "name": "The Assistant",
-      "description": "Don't touch that!",
-      "condition": "Make the submarine's outer shell visible."
+      "name": "L'assistant",
+      "description": "Ne touche pas ça!",
+      "condition": "Rendre visible la coque extérieure du sous-marin."
     },
     "surimuki": {
       "name": "Surimuki",
-      "description": "\"I got scraped.\"",
-      "condition": "Find Surimuki everywhere she appears in the dream world (Broken Faces Area, a book in the Library, and the Monochrome School's rooftop)"
+      "description": "\"Je me suis fait avoir.\"",
+      "condition": "Trouver Surimuki partout où elle apparaît dans le monde des rêves (Broken Faces Area, un livre dans la Library, et le toit de la Monochrome School)"
     },
     "helmet_girl": {
-      "name": "Shine On",
-      "description": "I'll see you on the dark side of the moon.",
-      "condition": "Visit Helmet Girl in Square-Square World, her apartment, and in the Moonlit Purple Balcony."
+      "name": "Brillance",
+      "description": "On se reverra sur la face cachée de la lune.",
+      "condition": "Rendre visite à l'Helmet Girl dans le Square-Square World, son appartement, et au Balcon Violet éclairé par la lueur de la lune."
     },
     "garden_of_dreams": {
-      "name": "Garden of Dreams",
-      "description": "In this vast world of dreams, like a garden that grows, grows, and grows",
-      "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden ,Scenic Outlook, and Evergreen Woods"
+      "name": "Jardin des rêves",
+      "description": "Dans ce vaste monde des rêves, comme un jardin qui grandit, grandit, et grandit",
+      "condition": " Interagir avec (ou entrer dans la salle contenant) les arbres des Mountaintop Ruins, de la Blood Cell Sea (incluant son état qliphothique), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, et Evergreen Woods"
     },
     "infinite_library_mirror": {
-      "name": "Lose Yourself",
-      "description": "Witness your reflection in a mirror beyond the seemingly-infinite.",
-      "condition": "Face yourself in the mirror and reach Static Noise Hell through Infinite Library."
+      "name": "Désorientée",
+      "description": "Invoque ta réflection dans un miroir passé un semi-infini.",
+      "condition": "Regarde-toi dans le miroir et atteindre Static Noise Hell depuis l'Infinite Library."
     }
   },
   "flow": {
@@ -1260,18 +1260,18 @@
       "condition": "Débloquer le thème de menu Orange. Si vous l'avez déjà débloqué, retournez là où vous l'avez trouvé."
     },
     "moonlight_flower": {
-      "name": "Moonside Flower",
-      "description": "Rainbow Flower Party!",
-      "condition": "Interact with the flower in Psychedelic Town and see the Rainbow Flower event."
+      "name": "Fleur au côté lunaire",
+      "description": "Fête de la fleur arc-en-ciel!",
+      "condition": "Interagir avec la fleur dans la Psychedelic Town et voir l'événement de la Fleur Arc-en-ciel."
     },
     "oreko": {
       "name": "Oreko",
-      "condition": "Obtain the Diving Helmet effect"
+      "condition": "Obtenir l'effet Casque de plongée"
     },
     "onigo_childbirth": {
-      "name": "Onigo Childbirth",
-      "description": "See the Childbirth event",
-      "condition": "Trigger the Childbirth event in Visceral World"
+      "name": "Accouchement d'Onigo",
+      "description": "Voir l'événement d'accouchement",
+      "condition": "Déclencher l'événement d'accouchement dans le Visceral World"
     }
   },
   "prayers": {
@@ -1321,19 +1321,19 @@
       "condition": "Entrer dans la salle contenant la prière Nourriture"
     },
     "submarine_cat_eyes": {
-      "name": "Thalassophobia",
-      "description": "When you stare into an abyss for a long time, the abyss also stares into you.",
-      "condition": "See the Underwater Ship Cat Eyes event in the Sunken Submarine"
+      "name": "Thalassophobie",
+      "description": "Quand tu observes dans un abysse pour un long moment, l'abysse te regarde en retour.",
+      "condition": "Voir l'événement de l'Underwater Ship Cat Eyes dans le Sunken Submarine"
     },
     "lookout_point": {
-      "name": "Lookout Point",
-      "description": "Not a gameboy in sight, just spirits living in the moment.",
-      "condition": "Visit the second island of Silhouette World via Symbol Maze."
+      "name": "Point d'observation",
+      "description": "Pas une gameboy en vue, juste des âmes profitant du moment.",
+      "condition": "Visiter la seconde île du Silhouette World par le Symbol Maze."
     },
     "phantom_symbols": {
-      "name": "Phantom Symbols",
-      "description": "Bear witness to your own ghost.",
-      "condition": "Interact with the Ghost Fluorette in the Symbols Maze."
+      "name": "Symboles fantomatiques",
+      "description": "Portes ressemblance à ton propre fantôme.",
+      "condition": "Interagir avec la Fluorette Fantomatique dans le Symbols Maze."
     }
   },
   "deepdreams": {
@@ -1348,7 +1348,7 @@
     },
     "planetarium": {
       "name": "Au-delà des étoiles",
-      "condition": "Entrer dans la salle dans le Planetarium contenant l'alter Céleste"
+      "condition": "Entrer dans la salle du Planetarium contenant l'alter Céleste"
     },
     "hospital_event": {
       "name": "Patient 001",
@@ -1370,24 +1370,24 @@
       "condition": "Acheter le maillot de bain dans les bains publics"
     },
     "warm_embrace": {
-      "name": "A Warm Embrace",
-      "description": "Share a hug with Tetsuko.",
-      "condition": "See Tetsuko's event in her room within the Subnexus."
+      "name": "Une chaleureuse étreinte",
+      "description": "Partager un câlin avec Tetsuko.",
+      "condition": "Voir l'événement de Tetsuko dans sa chambre dans le Subnexus."
     },
     "apparition_creature": {
-      "name": "Pastel Phantom",
-      "description": "A past of pastel",
-      "condition": "Enter the room containing the Apparition alter using the Pastel alter"
+      "name": "Fantôme pastel",
+      "description": "Un passé de pastel",
+      "condition": "Entrer dans la salle contenant l'alter Apparition en utilisant l'alter Pastel"
     },
     "pink_bathing_creature": {
-      "name": "Bath House Bubbles",
-      "description": "Enjoy the soothing company~",
-      "condition": "Find the pink bathing creature in the Bath House"
+      "name": "Bulles des bains publics",
+      "description": "Profites d'une apaisante companie~",
+      "condition": "Trouver la créature rose qui se baigne dans la Bath House"
     },
     "spa_day": {
-      "name": "Spa Day",
-      "description": "Time to take a break!",
-      "condition": "Relax in the jacuzzi in the Bath House"
+      "name": "Jour du spa",
+      "description": "C'est l'heure de prendre une pause!",
+      "condition": "Se relaxer dans le jacuzzi dans la Bath House"
     }
   },
   "someday": {
@@ -1410,12 +1410,12 @@
     "over_8k": {
       "name": "zaP-Rank",
       "description": "It's over 8000!",
-      "condition": "Achieve a score of 8000 or more on Level 7 of Zapnef"
+      "condition": "Obtenir un score de 8000 ou plus sur le Level 7 de Zapnef"
     },
     "hollow_head": {
-      "name": "Hollow Head",
-      "description": "\"you gotta go to the sospital and get the heeh raura effef so you can heal the glilg in the suswew\" - Jojogape",
-      "condition": "Reach The Void from the Subway."
+      "name": "Tête creuse",
+      "description": "\"tu dois aller au sospital et obtenir l'effef raura pour que tu soignes ce twou dans ta caboshee\" - Jojogape",
+      "condition": "Atteindre la Void depuis le Subway."
     }
   },
   "unevendream": {
@@ -1446,7 +1446,7 @@
     "blockgirl": {
       "name": "Blockgirl",
       "description": "Vivre sa meilleure vie",
-      "condition": "Interagir avec Blockgirl avec l'effet Music Box"
+      "condition": "Interagir avec Blockgirl avec l'effet Boîte à musique"
     },
     "deer": {
       "name": "Biche confinée",
@@ -1494,7 +1494,7 @@
     },
     "eye_flower": {
       "name": "Fleur à l'œil",
-      "condition": "Utiliser l'effet Seer proche d'une certaine fleur dans l'Alien Plants World pour la faire bourgeonner"
+      "condition": "Utiliser l'effet Voyant proche d'une certaine fleur dans l'Alien Plants World pour la faire bourgeonner"
     },
     "arcade": {
       "name": "Brillante arcade",
@@ -1509,7 +1509,7 @@
       "condition": "Voir l'événement du Rêve Corrodé"
     },
     "pinball_machine": {
-      "name": "En bas du tablier",
+      "name": "En bas de l'avant-scène",
       "description": "Allons faire quelque parties de pinball!",
       "condition": "Visiter la Pinball Machine"
     },
@@ -1518,13 +1518,13 @@
       "condition": "Obtenir un bernard-l'ermite dans un distributeur automatique"
     },
     "mimic": {
-      "name": "Mimic Engineer",
-      "description": "Way of The Dreamy Mime",
-      "condition": "Enter the Upside-Down event's area"
+      "name": "Ingénieur imitateur",
+      "description": "La voie de l'imitateur onirique",
+      "condition": "Entrer dans la salle de l'événement Tête en Bas"
     },
     "cube_racing": {
       "name": "Cube Racing",
-      "condition": "Witness the 78 Skidoo event in the Cube Road."
+      "condition": "Déclencher l'événement du 78 Skidoo dans la Cube Road."
     }
   },
   "braingirl": {
@@ -1574,24 +1574,24 @@
       "condition": "Utiliser la clé Vis pour s'enterrer dans le sol dans le Rainbow Screw Floor"
     },
     "sequoia_wheel_loss": {
-      "name": "The house always wins",
-      "description": "Face the consequences of your losses",
-      "condition": "Roll the worst result on the Sequoia Lucky Forest wheels and get caught by the chasers"
+      "name": "La maison gagne toujours",
+      "description": "Affronte les conséquences de tes pertes",
+      "condition": "Lancer le pire résultat sur l'une des roues de la Sequoia Lucky Forest et se faire attraper par l'un des chasseurs"
     },
     "residential_corridor_balcony": {
-      "name": "Industrial Society and Its Future",
-      "description": "What a polluted view...",
-      "condition": "Admire the view from the balcony of Residential Corridor World."
+      "name": "La Société industrielle et son avenir",
+      "description": "Quelle vue polluée...",
+      "condition": "Admirer la vue depuis le balcon du Residential Corridor World."
     },
     "pouleine_ride": {
-      "name": "Eggcellent Eggsersice",
-      "description": "Take a ride on the chicken to the beach!",
-      "condition": "Activate the Pouleine Ride event"
+      "name": "Eggcellent Eggsercice",
+      "description": "Faire une balade sur le poulet vers la plage!",
+      "condition": "Activer l'événement du Voyage de Pouleine"
     },
     "midnight_mall_haircut": {
-      "name": "Stylin'!",
-      "description": "Follow the latest trends!",
-      "condition": "Get a haircut at the Midnight Mall Hairdresser (with Cougar key)"
+      "name": "Stylé'!",
+      "description": "Suivre les dernières tendances!",
+      "condition": "Obtenir une coiffure au Coiffeur du Midnight Mall (avec la clé Cougar)"
     }
   }
 }


### PR DESCRIPTION
Translation of the new badges in French, and some fixs which can be found here:
- Fixed Sunken City badge title being wrong due to the wrong gender used for Sunken. (Was probably thinking of the word Bâtisse when originally making this, explaining the error)
- Fixed a typo in Green Tea Cake badge description.
- Edited Planetarium badge description to use a better and shorter formulation.
- Translated effects in Uneven Dream badges descriptions to match the upcoming French translation.
- Fixed the Pinball badge title using a literal translation of Apron instead of the intended Pinball specific term.