### PR TITLE
[2kki] Triple Decker Cake Badge Value Bug Fix

### DIFF
--- a/conditions/2kki/wedding_cake.json
+++ b/conditions/2kki/wedding_cake.json
@@ -1,4 +1,4 @@
 {
   "varId": 67,
-  "varValue": 110
+  "varValue": 111
 }


### PR DESCRIPTION
Fixed an issue where the badge could have been got by getting the Oyster Shell instead of the Triple Decker Cake due to a wrong value used (thanks jams and their friend for the bug issue).