### PR TITLE
[2kki] Moonview Lane badges bug fix

### DIFF
--- a/conditions/2kki/moonview_lane.json
+++ b/conditions/2kki/moonview_lane.json
@@ -1,7 +1,8 @@
 {
   "map": 1387,
-  "trigger": "prevMap",
-  "value": "1384",
-  "mapX2": 32,
-  "mapY2": 32
+  "mapX1": 12,
+  "mapY1": 14,
+  "mapX2": 19,
+  "mapY2": 21,
+  "trigger": "coords"
 }

--- a/conditions/2kki/moonview_lane_trial.json
+++ b/conditions/2kki/moonview_lane_trial.json
@@ -4,6 +4,6 @@
   "mapY1": 14,
   "mapX2": 19,
   "mapY2": 21,
-  "trigger": "coords"
+  "trigger": "coords",
   "timeTrial": true
 }

--- a/conditions/2kki/moonview_lane_trial.json
+++ b/conditions/2kki/moonview_lane_trial.json
@@ -1,8 +1,9 @@
 {
   "map": 1387,
-  "trigger": "prevMap",
-  "value": "1384",
-  "mapX2": 32,
-  "mapY2": 32,
+  "mapX1": 12,
+  "mapY1": 14,
+  "mapX2": 19,
+  "mapY2": 21,
+  "trigger": "coords"
   "timeTrial": true
 }


### PR DESCRIPTION
Fixed an issue where the badge could have been got from Animal Trophy Land instead of the intended Moonview Lane. The files are correct but I'm not sure why this check was not used back when the release was done, maybe it was not possible back then or there's an issue with Time Trial since I've not seen this trigger used for the others Time Trial badges?