### PR TITLE
Attempt to fix broken badges

### DIFF
--- a/conditions/2kki/libra_palace_scale.json
+++ b/conditions/2kki/libra_palace_scale.json
@@ -1,5 +1,9 @@
 {
-  "map": 699,
-  "trigger": "eventAction",
-  "value": "473"
+  "map": 1385,
+  "trigger": "prevMap",
+  "value": "699",
+  "mapX1": 27,
+  "mapY1": 85,
+  "mapX2": 33,
+  "mapY2": 90
 }

--- a/conditions/2kki/rainbow_fish_blue.json
+++ b/conditions/2kki/rainbow_fish_blue.json
@@ -1,12 +1,6 @@
 {
   "map": 642,
-  "switchIds": [
-    "1",
-    "2"
-  ],
-  "switchValues": [
-    true,
-    true
-  ],
+  "switchIds": [ 1, 2 ],
+  "switchValues": [ true, true ],
   "switchDelay": true
 }

--- a/conditions/2kki/rainbow_fish_green.json
+++ b/conditions/2kki/rainbow_fish_green.json
@@ -1,12 +1,6 @@
 {
   "map": 643,
-  "switchIds": [
-    "1",
-    "2"
-  ],
-  "switchValues": [
-    true,
-    true
-  ],
+  "switchIds": [ 1, 2 ],
+  "switchValues": [ true, true ],
   "switchDelay": true
 }

--- a/conditions/2kki/wedding_cake.json
+++ b/conditions/2kki/wedding_cake.json
@@ -1,4 +1,5 @@
 {
   "varId": 67,
-  "varValue": 111
+  "varValue": 111,
+  "varDelay": true
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1379,7 +1379,7 @@
       "condition": "Écouter la musique de la créature balle orange dans le Maple Shrine"
     },
     "jiangshi": {
-      "name": "Jiangshi!",
+      "name": "Jiangshi !",
       "condition": "Visiter le Nightmare Inn"
     }
   },


### PR DESCRIPTION
- Added specific coordinates to Libra Palace badge like how was previously done Moonview Lane.
- Changed how were written conditions for Binary Tower badge to work, based on how was done rainbow_bird.
- Added variable delay to Wedding Cake badge to make sure it work as intended and avoid getting it by getting the snack  of ID 112.
- Added a missing space to the Jiangshi badge in French.