### PR TITLE
Fixed a typo in Blood Ghosts badge (thanks renami for the report)

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -958,7 +958,7 @@
     "blood_ghosts": {
       "name": "Blood Ghosts",
       "description": "You shouldn't have done that.",
-      "condition": "Activate the Blood Sacrifice event in Blood Wotrld"
+      "condition": "Activate the Blood Sacrifice event in Blood World"
     },
     "scourge_of_guilt": {
       "name": "Scourge of Guilt",

--- a/lang/en.json
+++ b/lang/en.json
@@ -958,7 +958,7 @@
     "blood_ghosts": {
       "name": "Blood Ghosts",
       "description": "You shouldn't have done that.",
-      "condition": "Activate the Blood Sacrifice event in Blood Wotrld"
+      "condition": "Activate the Blood Sacrifice event in Blood World"
     },
     "scourge_of_guilt": {
       "name": "Scourge of Guilt",

--- a/lang/es.json
+++ b/lang/es.json
@@ -958,7 +958,7 @@
     "blood_ghosts": {
       "name": "Blood Ghosts",
       "description": "You shouldn't have done that.",
-      "condition": "Activate the Blood Sacrifice event in Blood Wotrld"
+      "condition": "Activate the Blood Sacrifice event in Blood World"
     },
     "scourge_of_guilt": {
       "name": "Scourge of Guilt",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -958,7 +958,7 @@
     "blood_ghosts": {
       "name": "피의 망령들 뱃지",
       "description": "그런 짓은 하지 말았어야지",
-      "condition": "Blood Wotrld에서 피의 희생(Blood Sacrific) 이벤트를 보기"
+      "condition": "Blood World에서 피의 희생(Blood Sacrific) 이벤트를 보기"
     },
     "scourge_of_guilt": {
       "name": "죄를 향한 채찍질 뱃지",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -958,7 +958,7 @@
     "blood_ghosts": {
       "name": "Fantasmas do Sangue",
       "description": "Você não deveria ter feito isso.",
-      "condition": "Ative o evento Blood Sacrifice em Blood Wotrld"
+      "condition": "Ative o evento Blood Sacrifice em Blood World"
     },
     "scourge_of_guilt": {
       "name": "Flagelo da Culpa",


### PR DESCRIPTION
Fixed a typo in Blood Ghosts badge description where Blood World was misspelled as "Blood Wotrld" (thanks renami for reporting this!)