### PR TITLE
Added Artist for Bluesteel Badge

### DIFF
--- a/badges/2kki/blue_house_road.json
+++ b/badges/2kki/blue_house_road.json
@@ -5,5 +5,6 @@
   "reqString": "blue_house_road",
   "map": 1374,
   "secret": true,
+  "art": "Roninnozlo",
   "batch": 22
 }


### PR DESCRIPTION
Fixed an issue where the artist Roninnozlo was not credited for the art of Bluesteel Badge (thanks JMG5 for the bug report).