### PR TITLE
Libra Scale and Rainbow Fish fix attempt

### DIFF
--- a/conditions/2kki/libra_palace_scale.json
+++ b/conditions/2kki/libra_palace_scale.json
@@ -1,9 +1,10 @@
 {
-  "map": 1385,
-  "trigger": "prevMap",
-  "value": "699",
-  "mapX1": 27,
-  "mapY1": 85,
-  "mapX2": 33,
-  "mapY2": 90
+  "map": 699,
+  "trigger": "eventAction",
+  "value": "473",
+  "switchId": 2984,
+  "switchValue": true,
+  "varId": 94,
+  "varValue": 3,
+  "varOp": ">="
 }

--- a/conditions/2kki/rainbow_fish_blue.json
+++ b/conditions/2kki/rainbow_fish_blue.json
@@ -1,6 +1,6 @@
 {
   "map": 642,
-  "switchIds": [ 1, 2 ],
-  "switchValues": [ true, true ],
+  "switchId": 2,
+  "switchValue": true,
   "switchDelay": true
 }

--- a/conditions/2kki/rainbow_fish_green.json
+++ b/conditions/2kki/rainbow_fish_green.json
@@ -1,6 +1,6 @@
 {
   "map": 643,
-  "switchIds": [ 1, 2 ],
-  "switchValues": [ true, true ],
+  "switchId": 2,
+  "switchValue": true,
   "switchDelay": true
 }


### PR DESCRIPTION
- Changed Libra Scale to an interaction in Constellation World (due to the use of both a variable and a switch it may still be broken)
- Changed Rainbow Fish to ask only one Switch instead of two, since anyways Switch 2 can't be ON if Switch 1 is OFF.