### PR TITLE
Update libra_palace_scale.json

### DIFF
--- a/conditions/2kki/libra_palace_scale.json
+++ b/conditions/2kki/libra_palace_scale.json
@@ -1,10 +1,10 @@
 {
   "map": 699,
-  "trigger": "eventAction",
-  "value": "473",
   "switchId": 2984,
   "switchValue": true,
   "varId": 94,
   "varValue": 3,
-  "varOp": ">="
+  "varOp": ">=",
+  "trigger": "eventAction",
+  "value": "473"
 }


### PR DESCRIPTION
Reorganized lines to make it match the order of the badges.go file. Probably my last attempt to fix it, if this still doesn't work the badge could be set as dev or we could change to just visit Libra Palace in Autumn as marked in the description.