### PR TITLE
Added a missing map location display for one of the badges

### DIFF
--- a/badges/2kki/white_garden.json
+++ b/badges/2kki/white_garden.json
@@ -6,6 +6,7 @@
     "white_garden_day",
     "white_garden_night"
   ],
+  "map": 1874,
   "art": "miau",
   "batch": 26
 }


### PR DESCRIPTION
Added a map location display for the White Garden badge of Miau.