### PR TITLE
Fixed a trigger issue with the TV Room badge

### DIFF
--- a/conditions/2kki/tv_room.json
+++ b/conditions/2kki/tv_room.json
@@ -1,3 +1,8 @@
 {
-  "map": 482
+  "map": 482,
+  "mapX1": 0,
+  "mapY1": 78,
+  "mapX2": 20,
+  "mapY2": 99,
+  "trigger": "coords"
 }


### PR DESCRIPTION
Fixed an issue where the badge could be obtained from the new sub-area of Heart World by adding boundaries to the badge.