### PR TITLE
Make checkboxes more consistent across translations

### DIFF
--- a/lang/ar.json
+++ b/lang/ar.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "المشروبات الصحية",
-      "condition": "اعثر على كل آلات البيع (3) واشتري شراباً من كل واحدة"
+      "condition": "اعثر على كل آلات البيع (3) واشتري شراباً من كل واحدة",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "النافذة",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Miniature Singularity",
-      "condition": "Find and interact with All 5 Black Hole Girls in Río's worlds. If you have already done so previously, you must visit the area where you found them."
+      "condition": "Interact with all 5 Black Hole Girls in Río's worlds, or revisit the areas where they appear (Decrepit Dwellings, Verdant Promenade, Forgotten Megalopolis, Tomb of Velleities: Lunar Sanctuary, Luminous Lake: Dragon's Peak)",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Escape from the Show",
@@ -1099,7 +1111,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1259,11 +1281,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1456,7 +1479,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2345,7 +2369,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3826,9 +3858,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4609,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5772,7 +5805,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5806,7 +5847,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6892,7 +6941,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6954,7 +7008,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7306,11 +7364,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4642,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4642,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/de.json
+++ b/lang/de.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Health Drinks",
-      "condition": "Find all 3 vending machines and buy a drink from each one"
+      "condition": "Buy a drink from all 3 vending machines in Dense Woods A, Hell, and Docks A",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Window",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Miniature Singularity",
-      "condition": "Find and interact with All 5 Black Hole Girls in Río's worlds. If you have already done so previously, you must visit the area where you found them."
+      "condition": "Interact with all 5 Black Hole Girls in Río's worlds, or revisit the areas where they appear (Decrepit Dwellings, Verdant Promenade, Forgotten Megalopolis, Tomb of Velleities: Lunar Sanctuary, Luminous Lake: Dragon's Peak)",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Escape from the Show",
@@ -1099,7 +1111,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1259,11 +1281,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1456,7 +1479,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2345,7 +2369,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3826,9 +3858,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4609,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5772,7 +5805,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5806,7 +5847,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6892,7 +6941,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6954,7 +7008,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7306,11 +7364,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4642,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/en.json
+++ b/lang/en.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Health Drinks",
-      "condition": "Find all 3 vending machines and buy a drink from each one"
+      "condition": "Buy a drink from all 3 vending machines in Dense Woods A, Hell, and Docks A",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Window",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Miniature Singularity",
-      "condition": "Find and interact with All 5 Black Hole Girls in Río's worlds. If you have already done so previously, you must visit the area where you found them."
+      "condition": "Interact with all 5 Black Hole Girls in Río's worlds, or revisit the areas where they appear (Decrepit Dwellings, Verdant Promenade, Forgotten Megalopolis, Tomb of Velleities: Lunar Sanctuary, Luminous Lake: Dragon's Peak)",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Escape from the Show",
@@ -1099,7 +1111,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1259,11 +1281,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1456,7 +1479,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2345,7 +2369,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3826,9 +3858,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4609,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5772,7 +5805,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5806,7 +5847,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6892,7 +6941,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6954,7 +7008,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7306,11 +7364,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/es.json
+++ b/lang/es.json
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4642,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/es.json
+++ b/lang/es.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Health Drinks",
-      "condition": "Find all 3 vending machines and buy a drink from each one"
+      "condition": "Buy a drink from all 3 vending machines in Dense Woods A, Hell, and Docks A",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Window",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Miniature Singularity",
-      "condition": "Find and interact with All 5 Black Hole Girls in Río's worlds. If you have already done so previously, you must visit the area where you found them."
+      "condition": "Interact with all 5 Black Hole Girls in Río's worlds, or revisit the areas where they appear (Decrepit Dwellings, Verdant Promenade, Forgotten Megalopolis, Tomb of Velleities: Lunar Sanctuary, Luminous Lake: Dragon's Peak)",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Escape from the Show",
@@ -1099,7 +1111,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1259,11 +1281,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1456,7 +1479,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2345,7 +2369,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3826,9 +3858,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4609,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5772,7 +5805,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5806,7 +5847,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6892,7 +6941,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6954,7 +7008,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7306,11 +7364,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -379,11 +379,7 @@
     },
     "wilderness_fan": {
       "name": "Exploratrice du désert",
-      "condition": "Visiter chaque zone des Wilderness",
-      "checkbox": {
-        "wilderness_50|wilderness_51|wilderness_52|wilderness_53|wilderness_54|wilderness_55|wilderness_56|wilderness_57|wilderness_58|wilderness_59|wilderness_60|wilderness_61|wilderness_62|wilderness_63|wilderness_64": "Wilderness",
-        "wilderness_65": "Hot Spring House"
-      }
+      "condition": "Visiter chaque zone des Wilderness"
     },
     "dave_death": {
       "name": "Dave-y Jones Locker",
@@ -881,7 +877,7 @@
         "downfall_garden_b": "Downfall Garden B",
         "sparkling_dimension_b": "Sparkling Dimension B",
         "opal_ruins_b": "Opal Ruins B",
-        "fuchsia_suburbs_b": "Originator Garden: Fuchsia Suburbs B"
+        "fuchsia_suburbs_b": "Fuchsia Suburbs B"
       }
     },
     "survivor": {
@@ -961,7 +957,7 @@
     "dream_fishing": {
       "name": "Prise onirique",
       "description": "Celui-là a l'air spécial",
-      "condition": "Visiter l'Ocean Subsurface, le Rotten Fish Lake, le Fish World, le Mackerel Desert, le Sushi World, le Flying Fish World, les Lamplit Stones, les Streetlight Docks, les Depths et les Bioluminescent Cavern",
+      "condition": "Visiter l'Ocean Subsurface, le Rotten Fish Lake, le Fish World, le Mackerel Desert, le Sushi World, le Flying Fish World, les Lamplit Stones, les Streetlight Docks, les Depths et le Bioluminescent Cavern",
       "checkbox": {
         "ocean_subsurface": "Ocean Subsurface",
         "rotten_fish_lake": "Rotten Fish Lake",
@@ -1289,7 +1285,8 @@
       "checkbox": {
         "garden_world_clock_pole": "Garden World (nuit)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1315,11 +1312,7 @@
     "plaza": {
       "name": "Hydroplaza",
       "description": "C'est pas une ville, c'est une grande place",
-      "condition": "Visiter chaque zone de la Poseidon Plaza",
-      "checkbox": {
-        "plaza_1|plaza_3|plaza_4|plaza_5": "Poseidon Plaza",
-        "plaza_2": "Deep Red Wilds"
-      }
+      "condition": "Visiter chaque zone de la Poseidon Plaza"
     },
     "robot": {
       "name": "Salle de stockage",
@@ -2381,7 +2374,10 @@
       "description": "Et on tourne, et on tourne, et on tourne...",
       "condition": "Visiter les 6 mondes présents sur le badge sans utiliser le téléporteur présent dans l'Oriental Pub",
       "checkbox": {
-        "humanoid_angry|humanoid_crying|humanoid_happy|humanoid_shocked": "Ice Cream Islands",
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
         "humanoid_green": "Platformer World",
         "humanoid_tired": "Abandoned Grounds"
       }
@@ -2479,7 +2475,7 @@
       "condition": "Rendre visite à Jimbo au Giant Desktop et voir le quatrième judas à Holiday Hell",
       "checkbox": {
         "jimbo_desktop": "Giant Desktop",
-        "jimbo_holiday": "Ice Cream Islands"
+        "jimbo_holiday": "Holiday Hell"
       }
     },
     "lone_penguin": {
@@ -2498,7 +2494,7 @@
         "honeycomb_world": "Honeycomb World",
         "pink_honeycomb": "Pink Honeycomb",
         "honeybee_laboratory": "Honeybee Laboratory",
-        "honeybee_residence": "Honeybee Residence: Honeybee Skyscraper"
+        "honeybee_residence": "Honeybee Residence"
       }
     },
     "vertigo_parasomnia": {
@@ -2564,7 +2560,7 @@
       "checkbox": {
         "cyclop_petal_hotel": "Petal Hotel",
         "cyclop_dream_pool": "Dream Pool",
-        "cyclop_silent_sewers": "Silent Sewers: Cyclops' Room",
+        "cyclop_silent_sewers": "Silent Sewers",
         "cyclop_teddy_bear": "Teddy Bear Land",
         "cyclop_red_street": "Red Streetlight World",
         "cyclop_acerola": "Acerola World",
@@ -2613,7 +2609,7 @@
         "flowers_hotel": "Travel Hotel",
         "flowers_creek": "Lost Creek",
         "flowers_fairy": "Snowy Forest",
-        "flowers_polycube": "Wooden Polycube Ruins: Icy Garden"
+        "flowers_polycube": "Wooden Polycube Ruins"
       }
     },
     "pudding_world_secrets": {
@@ -2726,11 +2722,7 @@
     "mask_collection": {
       "name": "Experte du déguisement",
       "description": "Qui seras-tu ?",
-      "condition": "Débloquer et voir tous les masques sans effet dans l'un des Mask Shops (En dehors de la Fille aux Couettes, Ahogeko, Moisobscure, Ange Prêtre, Kīgāru, Souris Blanche, Souris Noire, Créature Takoyaki et du Cône de signalisation)",
-      "checkbox": {
-        "mask_shop_s_twintail|mask_shop_s_bird|mask_shop_s_slime|mask_shop_s_guard|mask_shop_paint|mask_shop_uri|mask_shop_yukata|mask_shop_monmon|mask_shop_witch|mask_shop_prov|mask_shop_cat|mask_shop_appu|mask_shop_science|mask_shop_musume|mask_shop_otoko|mask_shop_tv|mask_shop_math|mask_shop_dogboa|mask_shop_huyure|mask_shop_eyeball|mask_shop_chain|mask_shop_fox|mask_shop_seal|mask_shop_candle|mask_shop_barrier|mask_shop_rune": "Mask Shop",
-        "mask_shop_s_twintail_d|mask_shop_s_bird_d|mask_shop_s_slime_d|mask_shop_s_guard_d|mask_shop_paint_d|mask_shop_uri_d|mask_shop_yukata_d|mask_shop_monmon_d|mask_shop_witch_d|mask_shop_prov_d|mask_shop_cat_d|mask_shop_appu_d|mask_shop_science_d|mask_shop_musume_d|mask_shop_otoko_d|mask_shop_tv_d|mask_shop_math_d|mask_shop_dogboa_d|mask_shop_huyure_d|mask_shop_eyeball_d|mask_shop_chain_d|mask_shop_fox_d|mask_shop_seal_d|mask_shop_candle_d|mask_shop_barrier_d|mask_shop_rune_d": "Deluxe Mask Shop"
-      }
+      "condition": "Débloquer et voir tous les masques sans effet dans l'un des Mask Shops (En dehors de la Fille aux Couettes, Ahogeko, Moisobscure, Ange Prêtre, Kīgāru, Souris Blanche, Souris Noire, Créature Takoyaki et du Cône de signalisation)"
     },
     "retro_cartridge_game": {
       "name": "Comme en 1981 !",
@@ -3395,8 +3387,10 @@
       "description": "Vieux tel un bon vin",
       "condition": "Dans la Japan Town, trouver la Maiko fantomatique, découvrir des créatures cachées dans une pièce isolée en utilisant l'effet Lunettes et interagir avec Kanban Otoko et News Man",
       "checkbox": {
-        "japan_town_hotel|japan_town_glasses": "Japan Town: The Hotel",
-        "japan_town_otoko|japan_town_news_man": "Japan Town"
+        "japan_town_hotel": "find the Ghost Maiko",
+        "japan_town_glasses": "discover some creatures hidden in an isolated room by using the Glasses effect",
+        "japan_town_otoko": "Kanban Otoko",
+        "japan_town_news_man": "News Man"
       }
     },
     "himalayan_lighthouse": {
@@ -3477,9 +3471,9 @@
         "urotsukis_dream_apartments": "Urotsuki's Dream Apartments",
         "drowsy_forest_room": "Drowsy Forest",
         "mirror_room": "Mirror Room",
-        "static_doppelganger_room": "Static Labyrinth: Doppelgänger Room",
+        "static_doppelganger_room": "Static Labyrinth",
         "bleak_future_main": "Bleak Future",
-        "vertigo_room": "Urotsuki's Dream Room: Vertigo"
+        "vertigo_room": "Vertigo"
       }
     },
     "2kki_canvas": {
@@ -3869,7 +3863,8 @@
       "description": "Est-ce que ces fléaux annonciateurs d'une perturbation sont des monstres ou des signes ? Et es-tu un outil du destin, ou le témoin d'un désastre ?",
       "condition": "Tronçonner les monstres rouges dans les mondes suivants : Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4323,11 +4318,7 @@
     "megusuri_uri_visine": {
       "name": "Marchand de larmes",
       "description": "Ces yeux sont très sensibles, donc il prend son travail très à cœur !",
-      "condition": "Trouver et interagir avec Megusuri Uri dans les trois parties différentes de Visine World",
-      "checkbox": {
-        "megusuri_uri_visine_1": "Visine World",
-        "megusuri_uri_visine_2|megusuri_uri_visine_3": "Visine World: Eye Shop"
-      }
+      "condition": "Trouver et interagir avec Megusuri Uri dans les trois parties différentes de Visine World"
     },
     "rgb_passage": {
       "name": "RGB Tile Path",
@@ -4353,14 +4344,14 @@
       "description": "Allons admirer les étoiles !",
       "condition": "Trouver les paysages nocturnes à Twisted Thickets, Foliage Estate, Submerged Communications Area, Shallows of Deceit, Nocturnal Grove, Windswept Scarlet Sands, Planetarium et Tomb of Velleities",
       "checkbox": {
-        "peak": "Twisted Thickets: The Peak",
+        "peak": "Twisted Thickets",
         "foliage_estate_satellite_dish": "Foliage Estate",
         "submerged_communications_area": "Submerged Communications Area",
         "shallows_of_deceit_rooftop": "Shallows of Deceit",
         "nocturnal_grove_boat": "Nocturnal Grove",
         "starry_night": "Windswept Scarlet Sands",
         "star_planetarium": "Planetarium",
-        "tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary"
+        "tomb_of_velleities": "Tomb of Velleities"
       }
     },
     "overgrowth_outlook": {
@@ -5823,8 +5814,8 @@
         "tubes_kondo": "Tubes",
         "purple_crystal": "Memory Graveyard",
         "corrupted_art_gallery_sh_e": "Empty Gallery",
-        "lsd_world": "LSD World (Dynamic)",
-        "kondo_ending_room|kondo_ending_room_2": "Kondo"
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
       }
     },
     "rusty_bubble": {
@@ -6342,8 +6333,8 @@
       "name": "Cheffe du puits",
       "condition": "Voir la personne au long cou dans le Mosquies' Village et rentrer dans le puits des Dark Lands",
       "checkbox": {
-        "mosquies_village_chief": "Mosquies' Village: The Wickedest Mosquy",
-        "well_dark_lands": "Quiet Path"
+        "mosquies_village_chief": "Mosquies' Village",
+        "well_dark_lands": "Dark Lands"
       }
     },
     "cartoonboy": {
@@ -6956,7 +6947,7 @@
       "condition": "Rencontrer toutes les jeunes Sometsuki",
       "checkbox": {
         "emerald_square": "Emerald Square",
-        "emerald_square_some": "Emerald Square: Back Alley",
+        "emerald_square_some": "Back Alley",
         "banquet_hall_some": "Banquet Hall"
       }
     },
@@ -7437,11 +7428,7 @@
     "duality_of_mom": {
       "name": "Maman...",
       "description": "Je t'aime, ne me blesse pas s'il te plaît.",
-      "condition": "Trouver la versions douce et la version flippante de la mère de A",
-      "checkbox": {
-        "mom_normal": "Nursery Room",
-        "mom_scary": "?"
-      }
+      "condition": "Trouver la versions douce et la version flippante de la mère de A"
     },
     "sacred_cats": {
       "name": "Chats sacrés",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -245,7 +245,7 @@
     },
     "bottles": {
       "name": "Boissons revigorantes",
-      "condition": "Trouver les 3 distributeurs automatiques et acheter une boisson dans chacun d'entre eux",
+      "condition": "Acheter une boisson des 3 distributeurs automatiques aux Dense Woods A, à Hell et aux Docks A",
       "checkbox": {
         "jihanki_dense_woods": "Dense Woods A",
         "jihanki_hell": "Hell",
@@ -640,7 +640,7 @@
     },
     "singularity": {
       "name": "Singularités miniatures",
-      "condition": "Trouver et interagir avec les 5 filles trou noir dans les mondes de Río. Si vous l'avez déjà fait précédemment, vous devez visiter chaque zone où vous les avez trouvées.",
+      "condition": "Interagir avec les 5 filles trou noir dans les mondes de Río, ou revisitez leur zone si vous avez déjà obtenu leur style de menu (Decrepit Dwellings, Verdant Promenade, Forgotten Megalopolis, Tomb of Velleities: Lunar Sanctuary et Luminous Lake: Dragon's Peak)",
       "checkbox": {
         "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
         "b_h_g_verdant_promenade": "Verdant Promenade",
@@ -957,7 +957,7 @@
     "dream_fishing": {
       "name": "Prise onirique",
       "description": "Celui-là a l'air spécial",
-      "condition": "Visiter l'Ocean Subsurface, le Rotten Fish Lake, le Fish World, le Mackerel Desert, le Sushi World, le Flying Fish World, les Lamplit Stones, les Streetlight Docks, les Depths et le Bioluminescent Cavern",
+      "condition": "Visiter l'Ocean Subsurface, le Rotten Fish Lake, le Fish World, le Mackerel Desert, le Sushi World, le Flying Fish World, les Lamplit Stones, les Streetlight Docks, les Depths et la Bioluminescent Cavern",
       "checkbox": {
         "ocean_subsurface": "Ocean Subsurface",
         "rotten_fish_lake": "Rotten Fish Lake",
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Souvenirs du nid chromatique",
-      "condition": "Obtenir les styles de menu 8-15 et 25. Pour tout ceux que vous avez déjà obtenu, retournez là où vous l'avez originellement trouvé.",
+      "condition": "Obtenir les styles de menu 8-15 et 25 à Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths et Viridian Wetlands. Pour tout ceux que vous avez déjà obtenu, retournez là où vous l'avez originellement trouvé.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -1281,11 +1281,11 @@
     "clock_pole": {
       "name": "Ponctualité",
       "description": "Toujours être ponctuel !",
-      "condition": "Trouver et approcher les pôles d'horloges dans le Garden World (nuit), la Blue Forest, le Botanical Garden (2), le Sculpture Park, le Twilight Park, la Monochrome School, la Sunrise Road, les Pure White Lands et le Critter Village",
+      "condition": "Trouver et approcher les pôles d'horloges dans le Garden World (nuit), la Blue Forest, le Botanical Garden (extérieur, passage), le Sculpture Park, le Twilight Park, la Monochrome School, la Sunrise Road, les Pure White Lands et le Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (nuit)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_1": "extérieur",
         "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
@@ -1477,7 +1477,8 @@
       "condition": " Interagir avec (ou entrer dans la salle contenant) les arbres des Mountaintop Ruins, de la Blood Cell Sea (incluant son état qliphothique), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, et Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "état qliphothique",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2372,7 +2373,7 @@
     "carousel_oriental": {
       "name": "Carrousel",
       "description": "Et on tourne, et on tourne, et on tourne...",
-      "condition": "Visiter les 6 mondes présents sur le badge sans utiliser le téléporteur présent dans l'Oriental Pub",
+      "condition": "Visiter les 6 mondes présents sur le badge sans utiliser le téléporteur présent dans l'Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
       "checkbox": {
         "humanoid_angry": "Test Facility",
         "humanoid_crying": "Holiday Hell",
@@ -3387,8 +3388,8 @@
       "description": "Vieux tel un bon vin",
       "condition": "Dans la Japan Town, trouver la Maiko fantomatique, découvrir des créatures cachées dans une pièce isolée en utilisant l'effet Lunettes et interagir avec Kanban Otoko et News Man",
       "checkbox": {
-        "japan_town_hotel": "find the Ghost Maiko",
-        "japan_town_glasses": "discover some creatures hidden in an isolated room by using the Glasses effect",
+        "japan_town_hotel": "trouver la Maiko fantomatique",
+        "japan_town_glasses": "découvrir des créatures cachées dans une pièce isolée en utilisant l'effet Lunettes",
         "japan_town_otoko": "Kanban Otoko",
         "japan_town_news_man": "News Man"
       }
@@ -3861,7 +3862,7 @@
     "red_monsters_qxy": {
       "name": "Spasmes cauchemardeques",
       "description": "Est-ce que ces fléaux annonciateurs d'une perturbation sont des monstres ou des signes ? Et es-tu un outil du destin, ou le témoin d'un désastre ?",
-      "condition": "Tronçonner les monstres rouges dans les mondes suivants : Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Tronçonner les monstres rouges dans les mondes suivants : Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
         "wooded_lakeside_1_monster": "Wooded Lakeside A",
         "wooded_lakeside_2_monster": "Wooded Lakeside B",
@@ -4645,7 +4646,7 @@
     "2kki_menu_67_70": {
       "name": "Prisme abstrait",
       "description": "Des joyaux en forme de prisme parmi les couleurs.",
-      "condition": "Obtenir les styles de menu 67-70. Pour tout ceux que vous avez déjà obtenu, retournez là où vous l'avez originellement trouvé.",
+      "condition": "Obtenir les styles de menu 67-70 à Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B et Snow Black. Pour tout ceux que vous avez déjà obtenu, retournez là où vous l'avez originellement trouvé.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5808,7 +5809,7 @@
     "kondo": {
       "name": "Kondo",
       "description": "Oui, c'est lui.",
-      "condition": "Voir Kondo dans tous les lieux où elle apparaît",
+      "condition": "Voir Kondo au Glitch World, à Tubes, au Memory Graveyard, à l'Empty Gallery, au LSD World et à Chaos",
       "checkbox": {
         "glitch_world_kondo": "Glitch World",
         "tubes_kondo": "Tubes",
@@ -5850,7 +5851,7 @@
     "lil_tsuki": {
       "name": "P'tit Tsuki",
       "description": "Le passé forge le futur.",
-      "condition": "Voir la version jeune d'Itsuki dans tous les lieux où il se trouve",
+      "condition": "Voir la version jeune d'Itsuki au School World, au Corrupted School World, au Glacier, à la Space Party, au Doodle World et dans l'Art Gallery",
       "checkbox": {
         "lil_tsuki_school": "School World",
         "lil_tsuki_corrupted": "Corrupted School World",
@@ -6944,10 +6945,10 @@
     "young_sometsuki": {
       "name": "Déshonneur d'antan",
       "description": "Qu'est-ce donc ? Qu'est-ce donc que tu as encore fait ?",
-      "condition": "Rencontrer toutes les jeunes Sometsuki",
+      "condition": "Rencontrer toutes les jeunes Sometsuki à l'Emerald Square (Ruelle incluse) et au Banquet Hall",
       "checkbox": {
         "emerald_square": "Emerald Square",
-        "emerald_square_some": "Back Alley",
+        "emerald_square_some": "Ruelle",
         "banquet_hall_some": "Banquet Hall"
       }
     },
@@ -7011,7 +7012,7 @@
     "eternal_love": {
       "name": "Amour éternel",
       "description": "« Je te suivrai jusqu'aux tréfonds de la terre,\nEt je t'y donnerai un baiser de renaissance. »",
-      "condition": "Sortir avec Alesandre dans les lieux où vous pouvez le rencontrer",
+      "condition": "Sortir avec Alesandre au Flooded Garden et au Rave Hall",
       "checkbox": {
         "flooded_garden_kiss": "Flooded Garden",
         "rave_rooftop_lovers": "Rave Hall"
@@ -7381,7 +7382,7 @@
     },
     "deep_forest": {
       "name": "Secrets parmi les branches",
-      "condition": "Visiter la Deep Forest A, B et C",
+      "condition": "Visiter la Deep Forest A, Deep Forest B et Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
         "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4642,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/it.json
+++ b/lang/it.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Health Drinks",
-      "condition": "Find all 3 vending machines and buy a drink from each one"
+      "condition": "Buy a drink from all 3 vending machines in Dense Woods A, Hell, and Docks A",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Window",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Miniature Singularity",
-      "condition": "Find and interact with All 5 Black Hole Girls in Río's worlds. If you have already done so previously, you must visit the area where you found them."
+      "condition": "Interact with all 5 Black Hole Girls in Río's worlds, or revisit the areas where they appear (Decrepit Dwellings, Verdant Promenade, Forgotten Megalopolis, Tomb of Velleities: Lunar Sanctuary, Luminous Lake: Dragon's Peak)",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Escape from the Show",
@@ -1099,7 +1111,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1259,11 +1281,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1456,7 +1479,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2345,7 +2369,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3826,9 +3858,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4609,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5772,7 +5805,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5806,7 +5847,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6892,7 +6941,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6954,7 +7008,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7306,11 +7364,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1315,7 +1315,8 @@
       "checkbox": {
         "garden_world_clock_pole": "植物世界",
         "blue_forest_clock_pole": "雨の森",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "水中植物園",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "彫刻庭園",
         "twilight_park_clock_pole": "月明かりの庭園",
         "monochrome_school_clock_pole": "モノクロ学校",
@@ -1341,11 +1342,7 @@
     "plaza": {
       "name": "海神の商店街",
       "description": "まるで一つの街のようだ",
-      "condition": "トライデントスクエアの全エリアに到達する",
-      "checkbox": {
-        "plaza_1|plaza_3|plaza_4|plaza_5": "トライデントスクエア",
-        "plaza_2": "古代遺跡世界"
-      }
+      "condition": "トライデントスクエアの全エリアに到達する"
     },
     "robot": {
       "name": "格納庫",
@@ -1498,7 +1495,7 @@
     "helmet_girl": {
       "name": "照射",
       "description": "I'll see you on the dark side of the moon.",
-      "condition": "四角四角、白い部屋にいる透明メットの女の子に会う。",
+      "condition": "四角四角、白い部屋、夜景ベランダにいる透明メットの女の子に会う。",
       "checkbox": {
         "helmet_girl_moonlit_balcony": "夜景ベランダ",
         "helmet_girl_apartment": "白い部屋",
@@ -1722,13 +1719,13 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "「私」は　此処に在る。",
-      "condition": "海底、バク、ケンキュウジョ(巨大)、夢の夢部屋、逆さ宿(隠しエリア)、赤い空の崖、拒絶、頭、赤黒迷路、色の無い谷、繫茂でもう一人のうろつきを目撃する",
+      "condition": "沖、バク、ケンキュウジョ(巨大)、夢の夢部屋、逆さ宿(隠しエリア)、赤い空の崖、拒絶、頭、赤黒迷路、色の無い谷、繫茂でもう一人のうろつきを目撃する",
       "checkbox": {
-        "uro_atlantis": "沖：沖合いエリア",
+        "uro_atlantis": "沖",
         "uro_tapir_place": "バク",
         "uro_cloning_room": "ケンキュウジョ",
         "uro_bleak_future": "夢の夢部屋",
-        "uro_pinwheel_path": "廃線：かざぐるまエリア",
+        "uro_pinwheel_path": "逆さ宿(隠しエリア)",
         "uro_red_sky_cliff": "赤い空の崖",
         "uro_despair_road": "拒絶",
         "uro_killed_head": "頭",
@@ -1945,13 +1942,7 @@
     "gb_memories": {
       "name": "GBメモリー",
       "description": "憶えてる？",
-      "condition": "グレーボーイ、グリーンボーイ、スケッチの大樹のすべての秘密を目撃し、NESトンネルの奥のベンチに座る",
-      "checkbox": {
-        "gb_change_color|gb_house_secret": "グレーボーイ",
-        "gb_flower_pot": "グリーンボーイ",
-        "nes_tunnel_bench": "NESトンネル",
-        "gb_forest_event": "スケッチ"
-      }
+      "condition": "グレーボーイ、グリーンボーイ、スケッチの大樹のすべての秘密を目撃し、NESトンネルの奥のベンチに座る"
     },
     "bunny_cocktail": {
       "name": "うさぎカクテル",
@@ -2071,7 +2062,7 @@
       "condition": "桟橋の森、水の都の森エリア、繫栄巣、人形屋敷、甘い嘘、樹海の遺跡、月街灯の森で虹色くらげを目撃する",
       "checkbox": {
         "sad_jellyfish_forest_pier": "桟橋の森",
-        "sad_jellyfish_chaotic_buildings": "水の都：森エリア",
+        "sad_jellyfish_chaotic_buildings": "水の都の森エリア",
         "sad_jellyfish_overgrown": "繁栄巣",
         "sad_jellyfish_doll_house": "人形屋敷",
         "sad_jellyfish_fantasy_isle": "甘い嘘",
@@ -2408,7 +2399,10 @@
       "description": "回レ回レ回レ回レ",
       "condition": "黒潰れの人から6つの世界を回る",
       "checkbox": {
-        "humanoid_angry|humanoid_crying|humanoid_happy|humanoid_shocked": "スマイルアイス",
+        "humanoid_angry": "人接児院",
+        "humanoid_crying": "雪恋墓卵",
+        "humanoid_happy": "スマイルアイス",
+        "humanoid_shocked": "青い宮殿",
         "humanoid_green": "2Dステージ",
         "humanoid_tired": "荒野と集落"
       }
@@ -2456,9 +2450,9 @@
       "description": "始まりの場所からここまで来たんですね。",
       "condition": "双子山が見える、森徊(山奥)、夕焼け、心象(心象エリア)、夢の夢部屋、彩愛蝶、rainyday、ハザマ、風力高原、銭湯を訪れる",
       "checkbox": {
-        "tw_foliage": "森徊",
+        "tw_foliage": "森徊(山奥)",
         "tw_fish": "夕焼け",
-        "tw_mirror": "心象",
+        "tw_mirror": "心象(心象エリア)",
         "tw_bleak": "夢の夢部屋",
         "tw_eyeball": "彩愛蝶",
         "tw_rainy": "rainyday",
@@ -2506,7 +2500,7 @@
       "condition": "3DRoomの黄色いミミズを訪ね、雪恋墓卵の4つ目の顔箱を調べる",
       "checkbox": {
         "jimbo_desktop": "3DRoom",
-        "jimbo_holiday": "スマイルアイス"
+        "jimbo_holiday": "雪恋墓卵"
       }
     },
     "lone_penguin": {
@@ -2525,7 +2519,7 @@
         "honeycomb_world": "ハチの巣",
         "pink_honeycomb": "ハニカムピンク",
         "honeybee_laboratory": "蜂蜜工場",
-        "honeybee_residence": "ハチミツビル"
+        "honeybee_residence": "ハチミツタウン"
       }
     },
     "vertigo_parasomnia": {
@@ -2567,7 +2561,7 @@
       "condition": "集束、廃線、アトリエ、文字世界で集束の顔を見つける",
       "checkbox": {
         "zalgo_magnet_room": "集束",
-        "zalgo_train_tracks": "廃線：線路エリア",
+        "zalgo_train_tracks": "廃線",
         "zalgo_atelier": "アトリエ",
         "zalgo_character": "文字世界"
       }
@@ -2626,7 +2620,7 @@
       "condition": "目覚めの森、havenの子ども部屋、幽谷、人柱、紫湖にある花の近くでむしになる",
       "checkbox": {
         "flowers_snow_forest": "目覚めの森",
-        "flowers_cotton": "haven",
+        "flowers_cotton": "havenの子ども部屋",
         "flowers_grove": "幽谷",
         "flowers_cloaked": "人柱",
         "flowers_lavender": "紫湖"
@@ -2639,18 +2633,14 @@
         "flowers_vortex": "水果",
         "flowers_hotel": "クラシックホテル",
         "flowers_creek": "垂水",
-        "flowers_fairy": "目覚めの森",
+        "flowers_fairy": "目覚めの森の花部屋",
         "flowers_polycube": "氷庭"
       }
     },
     "pudding_world_secrets": {
       "name": "焼きプリン",
       "description": "待って、火をつけたのならクリームブリュレじゃない？",
-      "condition": "めったに訪れないプリン世界の魅力を堪能し、その秘密をすべて見つける",
-      "checkbox": {
-        "pudding_teru|pudding_extinction|pudding_return|pudding_machine|pudding_mask": "プリン世界",
-        "pudding_liquor_street": "ガラス"
-      }
+      "condition": "めったに訪れないプリン世界の魅力を堪能し、その秘密をすべて見つける"
     },
     "eternal_dreamer": {
       "name": "目覚める時か、深い夢に落ちる時か？",
@@ -2762,11 +2752,7 @@
     "mask_collection": {
       "name": "変装の達人",
       "description": "今日は誰になる？",
-      "condition": "どこかのお面屋で、すっぴんで見られる全てのお面を解禁して見る(ツインテールの女の子、偽浅瀬の家の女の子、ふらんねる、ぜんまい少女、白ネズミ、黒ネズミ、たこやき、Angel Priest、パイロンを除く)",
-      "checkbox": {
-        "mask_shop_s_twintail|mask_shop_s_bird|mask_shop_s_slime|mask_shop_s_guard|mask_shop_paint|mask_shop_uri|mask_shop_yukata|mask_shop_monmon|mask_shop_witch|mask_shop_prov|mask_shop_cat|mask_shop_appu|mask_shop_science|mask_shop_musume|mask_shop_otoko|mask_shop_tv|mask_shop_math|mask_shop_dogboa|mask_shop_huyure|mask_shop_eyeball|mask_shop_chain|mask_shop_fox|mask_shop_seal|mask_shop_candle|mask_shop_barrier|mask_shop_rune": "お面屋",
-        "mask_shop_s_twintail_d|mask_shop_s_bird_d|mask_shop_s_slime_d|mask_shop_s_guard_d|mask_shop_paint_d|mask_shop_uri_d|mask_shop_yukata_d|mask_shop_monmon_d|mask_shop_witch_d|mask_shop_prov_d|mask_shop_cat_d|mask_shop_appu_d|mask_shop_science_d|mask_shop_musume_d|mask_shop_otoko_d|mask_shop_tv_d|mask_shop_math_d|mask_shop_dogboa_d|mask_shop_huyure_d|mask_shop_eyeball_d|mask_shop_chain_d|mask_shop_fox_d|mask_shop_seal_d|mask_shop_candle_d|mask_shop_barrier_d|mask_shop_rune_d": "高級お面屋"
-      }
+      "condition": "どこかのお面屋で、すっぴんで見られる全てのお面を解禁して見る(ツインテールの女の子、偽浅瀬の家の女の子、ふらんねる、ぜんまい少女、白ネズミ、黒ネズミ、たこやき、Angel Priest、パイロンを除く)"
     },
     "retro_cartridge_game": {
       "name": "１９７７年みたい！",
@@ -3268,8 +3254,8 @@
       "description": "砂糖美味しいいいいいいいいいいいいいいいいいいいいいいいいいいい!!!!!!!!!!!!!!",
       "condition": "お菓子がテーマの世界を到達する:チョコレートの通路、スイーツ、シュガー（うらも含む）、キャンディ、アイスクリー夢、スイートキューブ、チョコレー塔、スイーツホール（ストロベリーエリア）",
       "checkbox": {
-        "sugary_depths": "シュガー：うら",
-        "sugar_world": "シュガー：おもて",
+        "sugary_depths": "うら",
+        "sugar_world": "シュガー",
         "candy_cane_fields": "キャンディ",
         "ice_cream_dream": "アイスクリー夢",
         "cube_of_sweets": "スイートキューブ",
@@ -3435,8 +3421,10 @@
       "description": "ワインみたいなビンテージ",
       "condition": "逆さ宿の一階入り口でのっぺら女将を見つけ、薄暗い部屋にいる何かをめがねで発見し、昭和路地で指差しカンバンとバスを待つダンディな男性に話しかける",
       "checkbox": {
-        "japan_town_hotel|japan_town_glasses": "逆さ宿",
-        "japan_town_otoko|japan_town_news_man": "昭和路地"
+        "japan_town_hotel": "逆さ宿の一階入り口でのっぺら女将を見つけ",
+        "japan_town_glasses": "薄暗い部屋にいる何かをめがねで発見し",
+        "japan_town_otoko": "指差しカンバン",
+        "japan_town_news_man": "バスを待つダンディな男性"
       }
     },
     "himalayan_lighthouse": {
@@ -3514,7 +3502,7 @@
       "name": "うろつきシンドローム",
       "condition": "うろつき邸、部屋、心象、鏡の夢部屋、夢の夢部屋、うつろにあるうろつきの部屋を見る",
       "checkbox": {
-        "urotsukis_dream_apartments": "うろつき邸：似非現実部屋",
+        "urotsukis_dream_apartments": "うろつき邸",
         "drowsy_forest_room": "部屋",
         "mirror_room": "心象",
         "static_doppelganger_room": "鏡の夢部屋",
@@ -3757,8 +3745,8 @@
       "name": "六角遺跡",
       "condition": "六角タイル世界の灰色と赤色の六角タイル通路に到達する",
       "checkbox": {
-        "hexagonal_pillar_psg_a_1|hexagonal_pillar_psg_a_2": "六角タイル世界：六角柱通路・赤色",
-        "hexagonal_pillar_psg_b": "六角タイル世界：六角柱通路・灰色"
+        "hexagonal_pillar_psg_a_1|hexagonal_pillar_psg_a_2": "赤色",
+        "hexagonal_pillar_psg_b": "灰色"
       }
     },
     "graffiti_city_bot": {
@@ -3775,7 +3763,7 @@
       "name": "ツインツリーズ",
       "condition": "植物と網と植物世界陽境の両方に到達する",
       "checkbox": {
-        "blue_forest": "雨の森",
+        "blue_forest": "植物と網",
         "orange_forest": "植物世界陽境"
       }
     },
@@ -3908,8 +3896,10 @@
       "description": "これらの災厄は怪物なのか、それとも兆しなのか？あなたは運命の道具なのか、それとも災厄の目撃者なのか？",
       "condition": "釣り堀、万華鏡世界、ダムのほとり、六角タイル世界 (六角柱通路), 白い世界にいる赤い生物にチェーンソーを使う",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "湖のほとり：水路エリア",
-        "hexa_pillar_passage_monster|kaleidscope_world_monster": "六角タイル世界：六角柱通路・水晶",
+        "wooded_lakeside_1_monster": "湖のほとり",
+        "wooded_lakeside_2_monster": "ダムのほとり",
+        "hexa_pillar_passage_monster": "六角タイル世界 (六角柱通路)",
+        "kaleidscope_world_monster": "万華鏡世界",
         "streetlight_docks_monster": "釣り堀",
         "pure_white_lands_monster": "白い世界"
       }
@@ -4033,8 +4023,7 @@
         "beach_dream|beach_dream_b": "夢海岸",
         "beach_grand": "夢ビーチ",
         "beach_realistic_a|beach_realistic_b|beach_realistic_c|beach_realistic_d|beach_realistic_e|beach_realistic_f": "消波ブロックの砂浜",
-        "beach_blood_red_a": "薔薇色の浜辺",
-        "beach_blood_red_b": "薔薇薫る波打ち際"
+        "beach_blood_red_a|beach_blood_red_a": "薔薇色の浜辺"
       }
     },
     "wintry_attendant": {
@@ -4131,7 +4120,7 @@
         "b_w_mono_feudal_japan": "白黒城",
         "b_w_mono_abyss": "白黒深淵",
         "b_w_fused_faces_world": "顔",
-        "b_w_sea_of_clouds": "嘔吐庭",
+        "b_w_sea_of_clouds": "雲海",
         "b_w_mono_ranch": "無鳴牧場",
         "b_w_mono_street": "影絵",
         "b_w_doll_house": "人形屋敷"
@@ -4362,11 +4351,7 @@
     "megusuri_uri_visine": {
       "name": "目薬売り",
       "description": "この目は非常に繊細だから、彼は非常に気を遣う",
-      "condition": "目玉薬で3つのパターンの目薬売りを見つけて話しかける",
-      "checkbox": {
-        "megusuri_uri_visine_1": "目玉薬",
-        "megusuri_uri_visine_2|megusuri_uri_visine_3": "目薬川：目薬屋さん"
-      }
+      "condition": "目玉薬で3つのパターンの目薬売りを見つけて話しかける"
     },
     "rgb_passage": {
       "name": "RGBのタイル通路",
@@ -4392,14 +4377,14 @@
       "description": "今夜星を見に行こう",
       "condition": "霧の森、森徊、水没電柱、嘘つきの浅瀬、幽谷、砂と風、星の夜、Butterflyで夜空の風景を見つける",
       "checkbox": {
-        "peak": "霧の森：雨降る森",
+        "peak": "霧の森",
         "foliage_estate_satellite_dish": "森徊",
         "submerged_communications_area": "水没電柱",
-        "shallows_of_deceit_rooftop": "嘘つきの街：嘘つきの浅瀬",
+        "shallows_of_deceit_rooftop": "嘘つきの浅瀬",
         "nocturnal_grove_boat": "幽谷",
         "starry_night": "砂と風",
         "star_planetarium": "星の夜",
-        "tomb_of_velleities": "Butterfly：最奥"
+        "tomb_of_velleities": "Butterfly"
       }
     },
     "overgrowth_outlook": {
@@ -4693,7 +4678,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5327,9 +5312,9 @@
       "name": "オレンジ実験",
       "condition": "オレンジ回路の部屋、オレンジ地下通路、試験管が入ったオレンジ色の実験室に到達する",
       "checkbox": {
-        "orange_maze": "Orange Maze",
-        "orange_passage": "Orange Passage",
-        "orange_laboratory": "Orange Laboratory"
+        "orange_maze": "オレンジ回路の部屋",
+        "orange_passage": "オレンジ地下通路",
+        "orange_laboratory": "オレンジ色の実験室"
       }
     },
     "dark_city": {
@@ -5345,8 +5330,8 @@
       "description": "ピアノの音色がどこかへ導いてくれる…",
       "condition": "青通路と微生物に到達する",
       "checkbox": {
-        "microscopic_world": "Microorganism World",
-        "young_passage": "Young Passage"
+        "microscopic_world": "微生物",
+        "young_passage": "青通路"
       }
     },
     "attack_smile": {
@@ -5428,8 +5413,8 @@
       "name": "花柄帽子",
       "condition": "花子姉部屋と植物部屋で花子姉に会う",
       "checkbox": {
-        "flower_girl_plant": "Plant Corridors",
-        "flower_girl_illusion": "Illusionary Corridors"
+        "flower_girl_plant": "植物部屋",
+        "flower_girl_illusion": "花子姉部屋"
       }
     },
     "music_cube_flow": {
@@ -5862,8 +5847,8 @@
         "tubes_kondo": "Tubes",
         "purple_crystal": "Memory Graveyard",
         "corrupted_art_gallery_sh_e": "Empty Gallery",
-        "lsd_world": "LSD World (Dynamic)",
-        "kondo_ending_room|kondo_ending_room_2": "Kondo"
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
       }
     },
     "rusty_bubble": {
@@ -6226,11 +6211,11 @@
       "description": "いつでも景色を楽しめる",
       "condition": "朝、昼、夕、夜、嵐の状態でバルコニーに歩いて行く",
       "checkbox": {
-        "balcony_evening": "Balcony",
-        "balcony_day": "Balcony (Day)",
-        "balcony_night": "Balcony (Night)",
-        "balcony_morning": "Balcony (Morning)",
-        "balcony_storm": "Balcony (Storm)"
+        "balcony_evening": "夕",
+        "balcony_day": "昼",
+        "balcony_night": "夜",
+        "balcony_morning": "朝",
+        "balcony_storm": "嵐"
       }
     },
     "broken_bridge_monster": {
@@ -6381,8 +6366,8 @@
       "name": "井戸の中から",
       "condition": "Mosquies' Villageで首の長い人を見て、Dark Landsの井戸の中に入る",
       "checkbox": {
-        "mosquies_village_chief": "Mosquies' Village: The Wickedest Mosquy",
-        "well_dark_lands": "Quiet Path"
+        "mosquies_village_chief": "Mosquies' Village",
+        "well_dark_lands": "Dark Lands"
       }
     },
     "cartoonboy": {
@@ -7082,7 +7067,7 @@
     "cycle_palace": {
       "name": "天井の兄弟",
       "description": "太陽と月、大空のデュオ、\"銀河の陰陽\"",
-      "condition": "Night Palaceとthe Day Palaceに到達する",
+      "condition": "Night PalaceとDay Palaceに到達する",
       "checkbox": {
         "day_palace": "Day Palace",
         "night_palace": "Night Palace"
@@ -7476,11 +7461,7 @@
     "duality_of_mom": {
       "name": "ママ...",
       "description": "僕はママを愛してるから、どうか傷つけないで...",
-      "condition": "優しい状態と怖い状態のAの母を見つける",
-      "checkbox": {
-        "mom_normal": "おかあさん",
-        "mom_scary": "?"
-      }
+      "condition": "優しい状態と怖い状態のAの母を見つける"
     },
     "sacred_cats": {
       "name": "神聖ネコ",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -4678,7 +4678,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -372,19 +372,14 @@
       "description": "트리플",
       "condition": "삼각 두건 이펙트를 착용한 채로 달걀 귀신 유령(Nopperabou ghost), 빨간 유령(Fleebie)과 상호작용하고 식칼 이펙트로 파란 유령(Follony)을 찌르기",
       "checkbox": {
-        "ghostly_nopp": "어둠의 세계",
-        "ghostly_follony": "하수구",
-        "ghostly_fleebie": "콘크리트 폐허"
+        "ghostly_nopp": "귀신 유령(Nopperabou ghost)",
+        "ghostly_follony": "파란 유령(Follony)",
+        "ghostly_fleebie": "빨간 유령(Fleebie)"
       }
     },
     "wilderness_fan": {
       "name": "사막 탐험가",
-      "condition": "고비 사막의 모든 장소를 방문하기",
-      "checkbox": {
-        "wilderness_50|wilderness_51|wilderness_52|wilderness_53|wilderness_54|wilderness_55|wilderness_56|wilderness_57|wilderness_58|wilderness_59|wilderness_60|wilderness_61|wilderness_62|wilderness_63": "고비 사막",
-        "wilderness_64": "고비 사막 : 북부",
-        "wilderness_65": "고비 사막 : 온천"
-      }
+      "condition": "고비 사막의 모든 장소를 방문하기"
     },
     "dave_death": {
       "name": "데이비 존스의 보관함",
@@ -638,20 +633,20 @@
       "name": "몽환적인 사람들",
       "condition": "Underground Lake, Cliffside Woods, Radiant Stones Pathway를 방문하기",
       "checkbox": {
-        "underground_lake": "地底湖",
-        "cliffside_woods": "樹林空間",
-        "radiant_stones_pathway": "石跡"
+        "underground_lake": "Underground Lake",
+        "cliffside_woods": "Cliffside Woods",
+        "radiant_stones_pathway": "Radiant Stones Pathway"
       }
     },
     "singularity": {
       "name": "특이점 미니어쳐",
       "condition": "Río의 세계에 있는 모든 5명의 블랙홀 소녀와 상호작용하기 (이미 완료했다면, 발견했던 장소를 모두 방문할 것)",
       "checkbox": {
-        "b_h_g_decrepit_dwellings": "集合住宅",
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
         "b_h_g_verdant_promenade": "Verdant Promenade",
         "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
-        "b_h_g_tomb_of_velleities": "Butterfly：最奥",
-        "b_h_g_dragons_peak": "夢徨龍リオドリムス"
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
       }
     },
     "circus_lesser": {
@@ -749,7 +744,7 @@
       "checkbox": {
         "library": "Library",
         "infinite_library": "Infinite Library",
-        "mystery_library": "魔法図書館"
+        "mystery_library": "Mystery Library"
       }
     },
     "cosmic_cube": {
@@ -879,10 +874,10 @@
       "name": "B-사이드",
       "condition": "Downfall Garden B, Sparkling Dimension B, Opal Ruins B, Fuchsia Suburbs B에 방문하기",
       "checkbox": {
-        "downfall_garden_b": "嘔吐庭：血反吐エリア",
-        "sparkling_dimension_b": "黒潰れ：街灯と木のエリア",
-        "opal_ruins_b": "ミサロジー：陸（深層側）",
-        "fuchsia_suburbs_b": "反富裕：始祖庭側"
+        "downfall_garden_b": "Downfall Garden B",
+        "sparkling_dimension_b": "Sparkling Dimension B",
+        "opal_ruins_b": "Opal Ruins B",
+        "fuchsia_suburbs_b": "Fuchsia Suburbs B"
       }
     },
     "survivor": {
@@ -962,7 +957,7 @@
     "dream_fishing": {
       "name": "꿈낚시",
       "description": "이건 좀 독특하게 생겼네",
-      "condition": "Ocean Subsurface, Rotten Fish Lake, Fish World, Mackerel Desert, Sushi World, Flying Fish World, Lamplit Stones, Streetlight Docks, Depths, Bioluminescent Caverns를 방문하기",
+      "condition": "Ocean Subsurface, Rotten Fish Lake, Fish World, Mackerel Desert, Sushi World, Flying Fish World, Lamplit Stones, Streetlight Docks, Depths, Bioluminescent Cavern를 방문하기",
       "checkbox": {
         "ocean_subsurface": "Ocean Subsurface",
         "rotten_fish_lake": "Rotten Fish Lake",
@@ -972,8 +967,8 @@
         "fish_f_f_world": "Flying Fish World",
         "fish_lamplit": "Lamplit Stones",
         "fish_streetlight": "Streetlight Docks",
-        "fish_depths": "みなぞこ",
-        "fish_bioluminescent": "夜花草"
+        "fish_depths": "Depths",
+        "fish_bioluminescent": "Bioluminescent Cavern"
       }
     },
     "decrepit_smile": {
@@ -1004,18 +999,13 @@
         "01_digital_forest_1|01_digital_forest_2": "Digital Forest",
         "01_fluorescent_halls": "Fluorescent Halls",
         "01_corrupted_love_world": "Corrupted Love World",
-        "01_winter_valley": "深層：雪降る森エリア",
-        "01_bright_forest": "虹遺跡"
+        "01_winter_valley": "Winter Valley",
+        "01_bright_forest": "Bright Forest"
       }
     },
     "tetrapod": {
       "name": "테트라포드",
-      "condition": "Realistic Beach의 모든 에리어를 방문하기",
-      "checkbox": {
-        "realistic_beach_1|realistic_beach_2|realistic_beach_3|realistic_beach_4|realistic_beach_5|realistic_beach_6": "Realistic Beach",
-        "realistic_beach_7|realistic_beach_8|realistic_beach_9|realistic_beach_10": "消波ブロック内部",
-        "realistic_beach_11|realistic_beach_12": "消波ブロック内部奥"
-      }
+      "condition": "Realistic Beach의 모든 에리어를 방문하기"
     },
     "stellar_graveyard": {
       "name": "별의 묘지",
@@ -1126,11 +1116,10 @@
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
         "menu_theme_10": "Planetarium",
-        "b_h_g_antiquated_resthouse": "蒸気工場",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
         "menu_theme_12": "Rose Church",
-        "menu_theme_13": "夜花草",
-        "menu_theme_14": "みなぞこ",
-        "menu_theme_15": "すいそう",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
         "menu_theme_25": "Viridian Wetlands"
       }
     },
@@ -1198,12 +1187,12 @@
         "digital_hand_hub": "Stone World",
         "urban_street_area": "Urban Street Area",
         "the_docks": "The Docks",
-        "zalgo": "うつむき部屋",
-        "white_mushroom_field": "裏きのこ",
-        "crimson_labyrinth_mountains": "溶岩山",
+        "zalgo": "Magnet Room (Zalgo의 방?)",
+        "white_mushroom_field": "Mushroom World (하얀 버섯 세계)",
+        "crimson_labyrinth_mountains": "Crimson Labyrinth (붉은 산)",
         "color_cubes_world": "Color Cubes World",
-        "octagonal_grid_hub_passage": "Octagonal Grid Hub",
-        "obentou_world": "吐き気",
+        "octagonal_grid_hub_passage": "Octagonal Grid Hub (끊어진 통로)",
+        "obentou_world": "Obentou World",
         "entropy_dungeon": "Entropy Dungeon",
         "rainbow_towers": "Rainbow Towers"
       }
@@ -1257,21 +1246,7 @@
     "flying_fish_world": {
       "name": "너, 나 그리고 우리",
       "description": "어떻게 하나~ 우리 만남은 빙글빙글 돌고~",
-      "condition": "Flying Fish World의 메인 에리어와 모든 서브 에리어를 방문하기",
-      "checkbox": {
-        "flying_fish_world_1": "夕焼け",
-        "flying_fish_world_2|flying_fish_world_3": "待ち人",
-        "flying_fish_world_4|flying_fish_world_5": "正体不明",
-        "flying_fish_world_6": "古き良きテレビ",
-        "flying_fish_world_7": "頭蓋岩",
-        "flying_fish_world_8|flying_fish_world_14": "パース",
-        "flying_fish_world_9": "Flying Fish World",
-        "flying_fish_world_10": "怒りと血涙",
-        "flying_fish_world_11": "白い部屋",
-        "flying_fish_world_12": "夜景ベランダ",
-        "flying_fish_world_13": "鉢植え部屋：水槽と本棚のある鉢植え部屋",
-        "flying_fish_world_15": "時計"
-      }
+      "condition": "Flying Fish World의 메인 에리어와 모든 서브 에리어를 방문하기"
     },
     "sacred_crypt": {
       "name": "태초의 꿈",
@@ -1297,9 +1272,9 @@
       "description": "그녀는 누군가와 묘하게 닮았다...",
       "condition": "Hospital, Sky Kingdom, Train Tracks, Construction Frame Building 에 있는 모든 신비로운 메이드(Mysterious Maid) NPC를 찾아 상호작용하기",
       "checkbox": {
-        "m_m_hospital": "病院",
-        "m_m_sky_kingdom": "空中公園",
-        "m_m_train_tracks": "廃線：線路エリア",
+        "m_m_hospital": "Hospital",
+        "m_m_sky_kingdom": "Sky Kingdom",
+        "m_m_train_tracks": "Train Tracks",
         "m_m_construction_frame": "Construction Frame Building"
       }
     },
@@ -1308,9 +1283,10 @@
       "description": "시간은 금이라구!",
       "condition": "Garden World (밤), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands, Critter Village에 있는 모든 시계탑들과 상호작용하기",
       "checkbox": {
-        "garden_world_clock_pole": "Garden World",
-        "blue_forest_clock_pole": "雨の森",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden",
+        "garden_world_clock_pole": "Garden World (밤)",
+        "blue_forest_clock_pole": "Blue Forest",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1336,11 +1312,7 @@
     "plaza": {
       "name": "물의 플라자",
       "description": "여긴 도시보다 더 큰 플라자라구!",
-      "condition": "Poseidon Plaza의 모든 곳을 방문하기",
-      "checkbox": {
-        "plaza_1|plaza_3|plaza_4|plaza_5": "Poseidon Plaza",
-        "plaza_2": "古代遺跡世界"
-      }
+      "condition": "Poseidon Plaza의 모든 곳을 방문하기"
     },
     "robot": {
       "name": "보관소",
@@ -1356,10 +1328,11 @@
       "description": "가장 가치있는 전화기(Most Valued Phone)",
       "condition": "Aquatic Cube City, Fossil Lake, Sugar Road, Underground Garage, Water Reclamation Facility, Dark Museum, Dark Warehouse, Parking Zone와 Urotsuki's Dream Apartments를 연결하는 8개의 전화기 지름길을 모두 이용하기",
       "checkbox": {
-        "phone_aquatic_cube_city|phone_fossil_lake": "化石湖",
+        "phone_aquatic_cube_city": "Aquatic Cube City",
+        "phone_fossil_lake": "Fossil Lake",
         "phone_sugar_road": "Sugar Road",
         "phone_underground_garage": "Underground Garage",
-        "phone_water_reclamation_facility": "シャッター通り",
+        "phone_water_reclamation_facility": "Water Reclamation Facility",
         "phone_dark_museum": "Dark Museum",
         "phone_dark_warehouse": "Dark Warehouse",
         "phone_parking_zone": "Parking Zone"
@@ -1495,21 +1468,21 @@
       "description": "달의 어두운 쪽에서 만나자.",
       "condition": "Square-Square World, 그녀의 아파트 내부, Moonlit Purple Balcony 에서 헬멧 소녀(Helmet Girl) NPC를 만나기",
       "checkbox": {
-        "helmet_girl_moonlit_balcony": "夜景ベランダ",
-        "helmet_girl_apartment": "白い部屋",
+        "helmet_girl_moonlit_balcony": "Moonlit Purple Balcony",
+        "helmet_girl_apartment": "그녀의 아파트 내부",
         "helmet_girl_square2_world": "Square-Square World"
       }
     },
     "garden_of_dreams": {
       "name": "꿈들의 정원",
       "description": "이 광활한 꿈세계에서, 자라나고, 자라나는 정원처럼...",
-      "condition": "Mountaintop Ruins, Blood Cell Sea (반전 상태의 나무 포함), Graffiti Maze, Shinto Shrine, Azure Garden ,Scenic Outlook, Evergreen Woods 에 있는 나무 조형물(혹은 나무 모양의 월드 워프 물체)와 상호작용 하기",
+      "condition": "Mountaintop Ruins, Blood Cell Sea (반전 상태의 나무 포함), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, Evergreen Woods 에 있는 나무 조형물(혹은 나무 모양의 월드 워프 물체)와 상호작용 하기",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
         "tree_of_life_a|tree_of_life_b": "Blood Cell Sea",
         "graffiti_maze_tree": "Graffiti Maze",
-        "shinto_shrine_tree": "階段とブラザーサン",
-        "scenic_outlook_tree": "目の大樹",
+        "shinto_shrine_tree": "Shinto Shrine",
+        "scenic_outlook_tree": "Scenic Outlook",
         "evergreen_woods_tree": "Evergreen Woods",
         "azure_garden_tree": "Azure Garden"
       }
@@ -1719,17 +1692,17 @@
       "description": "\"나\" 는 여기 있어.",
       "condition": "Atlantis, Tapir-San's Place, Giant Cloning Room, Urotsuki's Dream Apartments, Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, Spear Tribe World에서 우로츠키 혹은, 그녀와 비슷한 지형과 만나기",
       "checkbox": {
-        "uro_atlantis": "沖：沖合いエリア",
-        "uro_tapir_place": "バク",
-        "uro_cloning_room": "ケンキュウジョ",
-        "uro_bleak_future": "夢の夢部屋",
-        "uro_pinwheel_path": "廃線：かざぐるまエリア",
+        "uro_atlantis": "Atlantis",
+        "uro_tapir_place": "Tapir-San's Place",
+        "uro_cloning_room": "Giant Cloning Room",
+        "uro_bleak_future": "Urotsuki's Dream Apartments",
+        "uro_pinwheel_path": "Closet Pinwheel Path",
         "uro_red_sky_cliff": "Red Sky Cliff",
         "uro_despair_road": "Despair Road",
         "uro_killed_head": "Head World",
         "uro_static_noise_hell": "Static Noise Hell",
         "uro_colorless_valley": "Colorless Valley",
-        "uro_spear_tribe_world": "繁茂"
+        "uro_spear_tribe_world": "Spear Tribe World"
       }
     },
     "blossoming_brooch": {
@@ -1940,13 +1913,7 @@
     "gb_memories": {
       "name": "게임보이 메모리즈",
       "description": "이거 기억나?",
-      "condition": "Monochrome GB World에 있는 모든 비밀들을 발견하고 NES Glitch Tunnel 맵 끝에 있는 벤치에 앉기",
-      "checkbox": {
-        "gb_change_color|gb_house_secret": "Monochrome GB World",
-        "gb_flower_pot": "グリーンボーイ",
-        "nes_tunnel_bench": "NES Glitch Tunnel",
-        "gb_forest_event": "Sketch Plains"
-      }
+      "condition": "Monochrome GB World에 있는 모든 비밀들을 발견하고 NES Glitch Tunnel 맵 끝에 있는 벤치에 앉기"
     },
     "bunny_cocktail": {
       "name": "토끼 칵테일",
@@ -2066,7 +2033,7 @@
       "condition": "Forest Pier, Chaotic Buildings, Overgrown Condominium, Doll House, Fantasy Isle, Monolith Jungle, Moonlight Lantern Forest에서 슬픈 해파리(Sad Jellyfish) NPC를 발견하기",
       "checkbox": {
         "sad_jellyfish_forest_pier": "Forest Pier",
-        "sad_jellyfish_chaotic_buildings": "水の都：森エリア",
+        "sad_jellyfish_chaotic_buildings": "Chaotic Buildings",
         "sad_jellyfish_overgrown": "Overgrown Condominium",
         "sad_jellyfish_doll_house": "Doll House",
         "sad_jellyfish_fantasy_isle": "Fantasy Isle",
@@ -2293,9 +2260,9 @@
       "description": "하나보다 둘이 낫지!",
       "condition": "Love Lodge의 마녀의 집에서 얼어붙은 자선의 마녀를 만나고 Hatred Palace에서 그림을 발견하기",
       "checkbox": {
-        "love_witch_house": "ハトレス",
-        "frozen_charity_witch": "氷漬けの街",
-        "painting_hatred_palace": "別離"
+        "love_witch_house": "Love Lodge의 마녀의 집",
+        "frozen_charity_witch": "얼어붙은 자선의 마녀",
+        "painting_hatred_palace": "Hatred Palace"
       }
     },
     "sanctuary_2kki": {
@@ -2403,7 +2370,10 @@
       "description": "돌고 돌고 돌고...",
       "condition": "Oriental Pub의 워프를 사용하지 않고 6개의 세계를 방문하기",
       "checkbox": {
-        "humanoid_angry|humanoid_crying|humanoid_happy|humanoid_shocked": "スマイルアイス",
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
         "humanoid_green": "Platformer World",
         "humanoid_tired": "Abandoned Grounds"
       }
@@ -2451,13 +2421,13 @@
       "description": "처음 시작된 장소로부터 이렇게나 멀리까지 왔구나.",
       "condition": "다음의 구역에서 쌍둥이 산이 보이는 장소들을 방문하기: Foliage Estate (Overlook 서브 에리어), Flying Fish World (Dream Scene 서브 에리어), Mirror Room (Beach 서브 에리어), Bleak Future, Saturated Eyeball Zone, Rainy Apartments, Red Sky Cliff (Splash Streetway 서브 에리어), Wind Turbine Plateau, Bathhouse",
       "checkbox": {
-        "tw_foliage": "Foliage Estate",
-        "tw_fish": "夕焼け",
-        "tw_mirror": "Mirror Room",
-        "tw_bleak": "夢の夢部屋",
+        "tw_foliage": "Foliage Estate (Overlook 서브 에리어)",
+        "tw_fish": "Flying Fish World (Dream Scene 서브 에리어)",
+        "tw_mirror": "Mirror Room (Beach 서브 에리어)",
+        "tw_bleak": "Bleak Future",
         "tw_eyeball": "Saturated Eyeball Zone",
         "tw_rainy": "Rainy Apartments",
-        "tw_red": "ハザマ",
+        "tw_red": "Red Sky Cliff (Splash Streetway 서브 에리어)",
         "tw_wind": "Wind Turbine Plateau",
         "tw_bathhouse": "Bathhouse"
       }
@@ -2501,7 +2471,7 @@
       "condition": "Giant Desktop과 Holiday Hell의 네 번째 작은 구멍에서 짐보를 발견하기",
       "checkbox": {
         "jimbo_desktop": "Giant Desktop",
-        "jimbo_holiday": "スマイルアイス"
+        "jimbo_holiday": "Holiday Hell"
       }
     },
     "lone_penguin": {
@@ -2519,8 +2489,8 @@
       "checkbox": {
         "honeycomb_world": "Honeycomb World",
         "pink_honeycomb": "Pink Honeycomb",
-        "honeybee_laboratory": "蜂蜜工場",
-        "honeybee_residence": "ハチミツビル"
+        "honeybee_laboratory": "Honeybee Laboratory",
+        "honeybee_residence": "Honeybee Residence"
       }
     },
     "vertigo_parasomnia": {
@@ -2540,9 +2510,9 @@
     },
     "nexus_collector": {
       "name": "넥서스 수집가",
-      "condition": "Dark Nexus, Second Nexus, Mini Nexus를 방문하기",
+      "condition": "Dark Nexus, Second Nexus, Mini-Nexus를 방문하기",
       "checkbox": {
-        "the_second_nexus": "The Second Nexus",
+        "the_second_nexus": "Second Nexus",
         "dark_nexus": "Dark Nexus",
         "mini_nexus": "Mini-Nexus"
       }
@@ -2561,8 +2531,8 @@
       "name": "Z̴̜̬̈́͐̒̄͑̃͛̄̊̕͝Ạ̶̭̮̰̯̱̠̠͖̜̲̯̈́̃͌͑̚͘ͅL̵̡̡̡͓͚̖̗̙̹̲̻̝͚̒͒͌G̷̝̜̦̱̠̝̮̲̺̝̽̓͜Ŏ̷͈́̔̚̕̕͝",
       "condition": "Magnet Room, Train Tracks, Atelier, Restored Character World에서 자르고를 발견하기",
       "checkbox": {
-        "zalgo_magnet_room": "集束",
-        "zalgo_train_tracks": "廃線：線路エリア",
+        "zalgo_magnet_room": "Magnet Room",
+        "zalgo_train_tracks": "Train Tracks",
         "zalgo_atelier": "Atelier",
         "zalgo_character": "Restored Character World"
       }
@@ -2586,7 +2556,7 @@
       "checkbox": {
         "cyclop_petal_hotel": "Petal Hotel",
         "cyclop_dream_pool": "Dream Pool",
-        "cyclop_silent_sewers": "コドモの部屋",
+        "cyclop_silent_sewers": "Silent Sewers",
         "cyclop_teddy_bear": "Teddy Bear Land",
         "cyclop_red_street": "Red Streetlight World",
         "cyclop_acerola": "Acerola World",
@@ -2624,28 +2594,24 @@
         "flowers_cotton": "Cotton Candy Haven",
         "flowers_grove": "Nocturnal Grove",
         "flowers_cloaked": "Cloaked Pillar World",
-        "flowers_lavender": "紫湖"
+        "flowers_lavender": "Lavender Waters"
       }
     },
     "flower_vision": {
       "name": "플라워 비전",
       "condition": "Flooded Dungeon (Floral Vortex), Travel Hotel, Lost Creek, Snowy Forest (Fairy Hole 서브 에리어), Wooden Polycube Ruins 에 위치한 꽃들 근처에서 벌레 이펙트를 장착하고 사용하기",
       "checkbox": {
-        "flowers_vortex": "水果",
+        "flowers_vortex": "Flooded Dungeon (Floral Vortex)",
         "flowers_hotel": "Travel Hotel",
-        "flowers_creek": "垂水",
-        "flowers_fairy": "Snowy Forest",
-        "flowers_polycube": "氷庭"
+        "flowers_creek": "Lost Creek",
+        "flowers_fairy": "Snowy Forest (Fairy Hole 서브 에리어)",
+        "flowers_polycube": "Wooden Polycube Ruins"
       }
     },
     "pudding_world_secrets": {
       "name": "푸딩 직감",
       "description": "잠깐, 이거 불 붙었으니까 일종의 크림 브륄레 같은 거 아냐?",
-      "condition": "거의 방문되어지지 않는 Pudding World 속의 모든 영광과 비밀을 파헤치기",
-      "checkbox": {
-        "pudding_teru|pudding_extinction|pudding_return|pudding_machine|pudding_mask": "Pudding World",
-        "pudding_liquor_street": "ガラス"
-      }
+      "condition": "거의 방문되어지지 않는 Pudding World 속의 모든 영광과 비밀을 파헤치기"
     },
     "eternal_dreamer": {
       "name": "깨어날 때인가, 아니면 더 깊은 꿈 속으로 들어갈 때인가?",
@@ -2654,7 +2620,7 @@
       "checkbox": {
         "dreamer_noise_hell": "Static Noise Hell",
         "dreamer_snow_forest": "Snowy Forest",
-        "dreamer_lavender": "紫湖",
+        "dreamer_lavender": "Lavender Waters",
         "dreamer_cube_city": "Aquatic Cube City",
         "dreamer_nowhere_home": "Home Within Nowhere",
         "dreamer_rainy": "Rainy Apartments",
@@ -2717,7 +2683,7 @@
         "moth_realm": "Entomophobia Realm",
         "moth_passage": "Butterfly Passage",
         "moth_grove": "Nocturnal Grove",
-        "moth_cosmic": "箱入りのコスモ"
+        "moth_cosmic": "Cosmic Cube World"
       }
     },
     "green_pattern_world": {
@@ -2752,11 +2718,7 @@
     "mask_collection": {
       "name": "변장의 달인",
       "description": "오늘은 어떤 것이 되어볼래?",
-      "condition": "Mask Shops에서 해금 가능한 모든 이펙트 불필요 가면을 취득하고 보기 (Twintail Girl, Ahogeko, Shadow Mold, Angel Priest, Kīgāru, White Mouse, Black Mouse, Takoyaki Creature, Traffic Cone)",
-      "checkbox": {
-        "mask_shop_s_twintail|mask_shop_s_bird|mask_shop_s_slime|mask_shop_s_guard|mask_shop_paint|mask_shop_uri|mask_shop_yukata|mask_shop_monmon|mask_shop_witch|mask_shop_prov|mask_shop_cat|mask_shop_appu|mask_shop_science|mask_shop_musume|mask_shop_otoko|mask_shop_tv|mask_shop_math|mask_shop_dogboa|mask_shop_huyure|mask_shop_eyeball|mask_shop_chain|mask_shop_fox|mask_shop_seal|mask_shop_candle|mask_shop_barrier|mask_shop_rune": "お面屋",
-        "mask_shop_s_twintail_d|mask_shop_s_bird_d|mask_shop_s_slime_d|mask_shop_s_guard_d|mask_shop_paint_d|mask_shop_uri_d|mask_shop_yukata_d|mask_shop_monmon_d|mask_shop_witch_d|mask_shop_prov_d|mask_shop_cat_d|mask_shop_appu_d|mask_shop_science_d|mask_shop_musume_d|mask_shop_otoko_d|mask_shop_tv_d|mask_shop_math_d|mask_shop_dogboa_d|mask_shop_huyure_d|mask_shop_eyeball_d|mask_shop_chain_d|mask_shop_fox_d|mask_shop_seal_d|mask_shop_candle_d|mask_shop_barrier_d|mask_shop_rune_d": "高級お面屋"
-      }
+      "condition": "Mask Shops에서 해금 가능한 모든 이펙트 불필요 가면을 취득하고 보기 (Twintail Girl, Ahogeko, Shadow Mold, Angel Priest, Kīgāru, White Mouse, Black Mouse, Takoyaki Creature, Traffic Cone)"
     },
     "retro_cartridge_game": {
       "name": "응답하라 1977!",
@@ -3259,12 +3221,12 @@
       "description": "맛있는 설탕...",
       "condition": "과자 테마인 Chocolate World, Cutlery World, Suagr World(Sugary Depths 포함), Candy Cane Fields, Ice Cream Dream, Cube of Sweets, Chocolate Tower, Dessert Fields(메인 지역)를 모두 방문하기",
       "checkbox": {
-        "sugary_depths": "シュガー：うら",
-        "sugar_world": "シュガー：おもて",
+        "sugary_depths": "Sugary Depths",
+        "sugar_world": "Sugar World",
         "candy_cane_fields": "Candy Cane Fields",
         "ice_cream_dream": "Ice Cream Dream",
         "cube_of_sweets": "Cube of Sweets",
-        "chocolate_tower": "チョコレー塔",
+        "chocolate_tower": "Chocolate Tower",
         "dessert_fields": "Dessert Fields",
         "chocolate_world": "Chocolate World",
         "cutlery_world": "Cutlery World"
@@ -3421,8 +3383,10 @@
       "description": "와인처럼 숙성된",
       "condition": "Japan Town에서 유령 마이코 NPC를 찾고, 안경 이펙트를 사용해 고립된 방에 있는 숨겨진 생명체들을 찾고, 화살표 간판 NPC, 신문을 읽는 NPC와 상호작용하기",
       "checkbox": {
-        "japan_town_hotel|japan_town_glasses": "逆さ宿",
-        "japan_town_otoko|japan_town_news_man": "昭和路地"
+        "japan_town_hotel": "유령 마이코 NPC를 찾고",
+        "japan_town_glasses": "안경 이펙트를 사용해 고립된 방에 있는 숨겨진 생명체들을 찾고",
+        "japan_town_otoko": "화살표 간판 NPC",
+        "japan_town_news_man": "신문을 읽는 NPC"
       }
     },
     "himalayan_lighthouse": {
@@ -3500,12 +3464,12 @@
       "name": "우로츠키 증후군",
       "condition": "Urotsuki's Dream Apartments의 우로츠키의 방, Drowsy Forest, Mirror Room, Static Labyrinth를 방문하고, Bleak Future와 Vertigo 이벤트를 보기",
       "checkbox": {
-        "urotsukis_dream_apartments": "うろつき邸：似非現実部屋",
-        "drowsy_forest_room": "部屋",
+        "urotsukis_dream_apartments": "Urotsuki's Dream Apartments",
+        "drowsy_forest_room": "Drowsy Forest",
         "mirror_room": "Mirror Room",
-        "static_doppelganger_room": "鏡の夢部屋",
-        "bleak_future_main": "夢の夢部屋",
-        "vertigo_room": "うつろ"
+        "static_doppelganger_room": "Static Labyrinth",
+        "bleak_future_main": "Bleak Future",
+        "vertigo_room": "Vertigo"
       }
     },
     "2kki_canvas": {
@@ -3761,7 +3725,7 @@
       "name": "쌍둥이 나무",
       "condition": "Blue Forest와 Orange Forest를 모두 방문하기",
       "checkbox": {
-        "blue_forest": "雨の森",
+        "blue_forest": "Blue Forest",
         "orange_forest": "Orange Forest"
       }
     },
@@ -3899,8 +3863,10 @@
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
       "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "湖のほとり：水路エリア",
-        "hexa_pillar_passage_monster|kaleidscope_world_monster": "六角タイル世界：六角柱通路・水晶",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
+        "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
+        "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
         "pure_white_lands_monster": "Pure White Lands"
       }
@@ -4021,12 +3987,10 @@
       "condition": "Visit Mixed Beach, Dream Beach, Grand Beach, Realistic Beach, and Blood Red Beach",
       "checkbox": {
         "beach_mixed_a|beach_mixed_b": "Mixed Beach",
-        "beach_dream": "Dream Beach",
-        "beach_dream_b": "夢海岸",
-        "beach_grand": "夢ビーチ",
+        "beach_dream|beach_dream_b": "Dream Beach",
+        "beach_grand": "Grand Beach",
         "beach_realistic_a|beach_realistic_b|beach_realistic_c|beach_realistic_d|beach_realistic_e|beach_realistic_f": "Realistic Beach",
-        "beach_blood_red_a": "Blood Red Beach",
-        "beach_blood_red_b": "薔薇薫る波打ち際"
+        "beach_blood_red_a|beach_blood_red_b": "Blood Red Beach"
       }
     },
     "wintry_attendant": {
@@ -4123,7 +4087,7 @@
         "b_w_mono_feudal_japan": "Monochrome Feudal Japan",
         "b_w_mono_abyss": "Monochromatic Abyss",
         "b_w_fused_faces_world": "Fused Faces World",
-        "b_w_sea_of_clouds": "嘔吐庭",
+        "b_w_sea_of_clouds": "Sea of Clouds",
         "b_w_mono_ranch": "Monochrome Ranch",
         "b_w_mono_street": "Monochrome Street",
         "b_w_doll_house": "Doll House"
@@ -4354,11 +4318,7 @@
     "megusuri_uri_visine": {
       "name": "Eye Drops Vendor",
       "description": "These eyes are very sensitive so he cares a lot about his work",
-      "condition": "Find and interact with Megusuri Uri in the three different parts of Visine World",
-      "checkbox": {
-        "megusuri_uri_visine_1": "Visine World",
-        "megusuri_uri_visine_2|megusuri_uri_visine_3": "目薬川：目薬屋さん"
-      }
+      "condition": "Find and interact with Megusuri Uri in the three different parts of Visine World"
     },
     "rgb_passage": {
       "name": "RGB Tile Path",
@@ -4384,14 +4344,14 @@
       "description": "Let's go stargazing!",
       "condition": "Find night sky sceneries in Twisted Thickets, Foliage Estate, Submerged Communications Area, Shallows of Deceit, Nocturnal Grove, Windswept Scarlet Sands, Planetarium, and Tomb of Velleities",
       "checkbox": {
-        "peak": "霧の森：雨降る森",
+        "peak": "Twisted Thickets",
         "foliage_estate_satellite_dish": "Foliage Estate",
         "submerged_communications_area": "Submerged Communications Area",
         "shallows_of_deceit_rooftop": "Shallows of Deceit",
         "nocturnal_grove_boat": "Nocturnal Grove",
         "starry_night": "Windswept Scarlet Sands",
-        "star_planetarium": "星の夜",
-        "tomb_of_velleities": "Butterfly：最奥"
+        "star_planetarium": "Planetarium",
+        "tomb_of_velleities": "Tomb of Velleities"
       }
     },
     "overgrowth_outlook": {
@@ -4685,7 +4645,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5321,7 +5281,7 @@
       "checkbox": {
         "orange_maze": "오렌지 미로",
         "orange_passage": "오렌지 통로",
-        "orange_laboratory": "오렌지 연구실"
+        "orange_laboratory": "오렌지 실험실"
       }
     },
     "dark_city": {
@@ -5335,7 +5295,7 @@
     "other_worlds": {
       "name": "이세계",
       "description": "피아노 소리에... 어딘가로 이끌려...",
-      "condition": "미시 세계에서 젊음의 통로에 방문하기",
+      "condition": "미생물 세계에서 젊음의 통로에 방문하기",
       "checkbox": {
         "microscopic_world": "미생물 세계",
         "young_passage": "젊음의 통로"
@@ -5854,8 +5814,8 @@
         "tubes_kondo": "Tubes",
         "purple_crystal": "Memory Graveyard",
         "corrupted_art_gallery_sh_e": "Empty Gallery",
-        "lsd_world": "LSD World (Dynamic)",
-        "kondo_ending_room|kondo_ending_room_2": "Kondo"
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
       }
     },
     "rusty_bubble": {
@@ -6218,11 +6178,11 @@
       "description": "언제든지 즐겁게 경치를 감상하기",
       "condition": "발코니에 입장하여 총 5개(아침, 점심, 저녁, 심야, 폭풍우)의 경치를 감상하기",
       "checkbox": {
-        "balcony_evening": "Balcony",
-        "balcony_day": "Balcony (Day)",
-        "balcony_night": "Balcony (Night)",
-        "balcony_morning": "Balcony (Morning)",
-        "balcony_storm": "Balcony (Storm)"
+        "balcony_evening": "저녁",
+        "balcony_day": "점심",
+        "balcony_night": "심야",
+        "balcony_morning": "아침",
+        "balcony_storm": "폭풍우"
       }
     },
     "broken_bridge_monster": {
@@ -6373,8 +6333,8 @@
       "name": "우물의 지배자",
       "condition": "Mosquies' Village에서 목이 긴 사람을 보고 Dark Lands의 우물 안에 들어가기",
       "checkbox": {
-        "mosquies_village_chief": "Mosquies' Village: The Wickedest Mosquy",
-        "well_dark_lands": "Quiet Path"
+        "mosquies_village_chief": "Mosquies' Village",
+        "well_dark_lands": "Dark Lands"
       }
     },
     "cartoonboy": {
@@ -6987,7 +6947,7 @@
       "condition": "모든 어린 소메츠키를 마주치기",
       "checkbox": {
         "emerald_square": "Emerald Square",
-        "emerald_square_some": "Emerald Square: Back Alley",
+        "emerald_square_some": "Back Alley",
         "banquet_hall_some": "Banquet Hall"
       }
     },
@@ -7468,11 +7428,7 @@
     "duality_of_mom": {
       "name": "Mom...",
       "description": "I love you, please don't hurt me.",
-      "condition": "Find both the sweet and scary versions of A's mom",
-      "checkbox": {
-        "mom_normal": "Nursery Room",
-        "mom_scary": "?"
-      }
+      "condition": "Find both the sweet and scary versions of A's mom"
     },
     "sacred_cats": {
       "name": "Sacred Cats",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -4645,7 +4645,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1106,7 +1106,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4637,7 +4637,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Napoje zdrowotne",
-      "condition": "Znajdź wszystkie 3 automaty z przekąskami i kup napoje z każdych z nich"
+      "condition": "Znajdź wszystkie 3 automaty z przekąskami i kup napoje z każdych z nich",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Okno",
@@ -630,7 +635,14 @@
     },
     "singularity": {
       "name": "Miniaturowe Załamanie",
-      "condition": "Znajdź i zainicjuj interakcje z wszystkimi 5 Black Hole Girls w światach Río's. Jeżeli zrobiłeś to już poprzeddnio, musisz ponownie wejść do tych obszarów."
+      "condition": "Znajdź i zainicjuj interakcje z wszystkimi 5 Black Hole Girls w światach Río's. Jeżeli zrobiłeś to już poprzeddnio, musisz ponownie wejść do tych obszarów.",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Ucieczka z Występu",
@@ -1094,7 +1106,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1254,11 +1276,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1451,7 +1474,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2340,7 +2364,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3821,9 +3853,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4604,7 +4637,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5767,7 +5800,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5801,7 +5842,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6887,7 +6936,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6949,7 +7003,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7301,11 +7359,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -372,18 +372,14 @@
       "description": "Trinca de espécie.",
       "condition": "Interaja com Nopperabou Ghost e Fleebie enquanto usa o efeito Spirit Headband e apunhale Follony com o efeito Kitchen Knife",
       "checkbox": {
-        "ghostly_nopp": "Dark World",
-        "ghostly_follony": "Sewers",
-        "ghostly_fleebie": "Ghost World"
+        "ghostly_nopp": "Nopperabou",
+        "ghostly_follony": "Follony",
+        "ghostly_fleebie": "Fleebie"
       }
     },
     "wilderness_fan": {
       "name": "Explorador do Deserto",
-      "condition": "Visite todas as áreas do Wilderness",
-      "checkbox": {
-        "wilderness_50|wilderness_51|wilderness_52|wilderness_53|wilderness_54|wilderness_55|wilderness_56|wilderness_57|wilderness_58|wilderness_59|wilderness_60|wilderness_61|wilderness_62|wilderness_63|wilderness_64": "Wilderness",
-        "wilderness_65": "Hot Spring House"
-      }
+      "condition": "Visite todas as áreas do Wilderness"
     },
     "dave_death": {
       "name": "Armário Dave-y Jones",
@@ -881,7 +877,7 @@
         "downfall_garden_b": "Downfall Garden B",
         "sparkling_dimension_b": "Sparkling Dimension B",
         "opal_ruins_b": "Opal Ruins B",
-        "fuchsia_suburbs_b": "Originator Garden: Fuchsia Suburbs B"
+        "fuchsia_suburbs_b": "Fuchsia Suburbs B"
       }
     },
     "survivor": {
@@ -1004,7 +1000,7 @@
         "01_fluorescent_halls": "Fluorescent Halls",
         "01_corrupted_love_world": "Corrupted Love World",
         "01_winter_valley": "Winter Valley",
-        "01_bright_forest": "Bright Forest: Rainbow Ruins"
+        "01_bright_forest": "Bright Forest"
       }
     },
     "tetrapod": {
@@ -1191,11 +1187,11 @@
         "digital_hand_hub": "Stone World",
         "urban_street_area": "Urban Street Area",
         "the_docks": "The Docks",
-        "zalgo": "Magnet Room: Zalgo's Room?",
-        "white_mushroom_field": "Mushroom World: White Mushroom Field",
-        "crimson_labyrinth_mountains": "Crimson Labyrinth",
+        "zalgo": "Magnet Room (Zalgo's Room?)",
+        "white_mushroom_field": "Mushroom World (White Mushroom Field)",
+        "crimson_labyrinth_mountains": "Crimson Labyrinth (Red Mountains)",
         "color_cubes_world": "Color Cubes World",
-        "octagonal_grid_hub_passage": "Octagonal Grid Hub",
+        "octagonal_grid_hub_passage": "Octagonal Grid Hub (Broken Passage)",
         "obentou_world": "Obentou World",
         "entropy_dungeon": "Entropy Dungeon",
         "rainbow_towers": "Rainbow Towers"
@@ -1289,7 +1285,8 @@
       "checkbox": {
         "garden_world_clock_pole": "Garden World (Dia)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1315,11 +1312,7 @@
     "plaza": {
       "name": "Hydroplaza",
       "description": "Isso não é uma cidade, mais sim uma praça!",
-      "condition": "Visite todas as áreas da Poseidon Plaza",
-      "checkbox": {
-        "plaza_1|plaza_3|plaza_4|plaza_5": "Poseidon Plaza",
-        "plaza_2": "Deep Red Wilds"
-      }
+      "condition": "Visite todas as áreas da Poseidon Plaza"
     },
     "robot": {
       "name": "Despensa",
@@ -1335,10 +1328,11 @@
       "description": "Digite este numero neste telefone.",
       "condition": "Utilize o atalho telefónico nos Urotsuki's Dream Apartments em todos os 8 locais dele: Aquatic Cube City, Fossil Lake, Sugar Road, Underground Garage, Water Reclamation Facility, Dark Museum e Dark Warehouse o Parking Zone",
       "checkbox": {
-        "phone_aquatic_cube_city|phone_fossil_lake": "Fossil Lake",
+        "phone_aquatic_cube_city": "Aquatic Cube City",
+        "phone_fossil_lake": "Fossil Lake",
         "phone_sugar_road": "Sugar Road",
         "phone_underground_garage": "Underground Garage",
-        "phone_water_reclamation_facility": "Water Reclamation Facility: Shutter Alley",
+        "phone_water_reclamation_facility": "Water Reclamation Facility",
         "phone_dark_museum": "Dark Museum",
         "phone_dark_warehouse": "Dark Warehouse",
         "phone_parking_zone": "Parking Zone"
@@ -1472,9 +1466,10 @@
     "helmet_girl": {
       "name": "Astronauta",
       "description": "Tá sentindo falta da Terra? Que falta que essa Terra te faz?",
-      "condition": "Visite Helmet Girl em Square-Square World, no seu apartment, e no Moonlit Purple Balcony.",
+      "condition": "Visite Helmet Girl em Square-Square World, no seu apartment, e no Moonlit Purple Balcony",
       "checkbox": {
-        "helmet_girl_moonlit_balcony|helmet_girl_apartment": "Flying Fish World",
+        "helmet_girl_moonlit_balcony": "no Moonlit Purple Balcony",
+        "helmet_girl_apartment": "no seu apartment",
         "helmet_girl_square2_world": "Square-Square World"
       }
     },
@@ -1699,15 +1694,15 @@
       "checkbox": {
         "uro_atlantis": "Atlantis",
         "uro_tapir_place": "Tapir-San's Place",
-        "uro_cloning_room": "Red Brick Maze: Cloning Room",
-        "uro_bleak_future": "Bleak Future",
+        "uro_cloning_room": "Giant Cloning Room",
+        "uro_bleak_future": "Urotsuki's Dream Apartments",
         "uro_pinwheel_path": "Closet Pinwheel Path",
         "uro_red_sky_cliff": "Red Sky Cliff",
         "uro_despair_road": "Despair Road",
         "uro_killed_head": "Head World",
         "uro_static_noise_hell": "Static Noise Hell",
         "uro_colorless_valley": "Colorless Valley",
-        "uro_spear_tribe_world": "Spear Tribe World: Overgrown Stone Area"
+        "uro_spear_tribe_world": "Spear Tribe World"
       }
     },
     "blossoming_brooch": {
@@ -1918,13 +1913,7 @@
     "gb_memories": {
       "name": "Memórias do GB",
       "description": "Lembra-se disso?",
-      "condition": "Testemunhe todos os segredos do Monochrome GB World e sente-se no banco no final do NES Glitch Tunnel.",
-      "checkbox": {
-        "gb_change_color|gb_house_secret": "Monochrome GB World",
-        "gb_flower_pot": "Monochrome GB World: GB Well",
-        "nes_tunnel_bench": "NES Glitch Tunnel",
-        "gb_forest_event": "Sketch Plains"
-      }
+      "condition": "Testemunhe todos os segredos do Monochrome GB World e sente-se no banco no final do NES Glitch Tunnel."
     },
     "bunny_cocktail": {
       "name": "Coquetél Coelhinho",
@@ -2271,8 +2260,8 @@
       "description": "Dois é melhor do que um!",
       "condition": "Visite a Witch's House em Love Lodge, o local onde está a Witch of Charity congelada, e encontre a pintura no Hatred Palace",
       "checkbox": {
-        "love_witch_house": "Love Lodge",
-        "frozen_charity_witch": "Snowy Suburbs",
+        "love_witch_house": "Witch's House em Love Lodge",
+        "frozen_charity_witch": "Witch of Charity",
         "painting_hatred_palace": "Hatred Palace"
       }
     },
@@ -2381,7 +2370,10 @@
       "description": "Roda e roda e roda...",
       "condition": "Visite os 6 mundos retratados sem usar a warp de Oriental Pub",
       "checkbox": {
-        "humanoid_angry|humanoid_crying|humanoid_happy|humanoid_shocked": "Ice Cream Islands",
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
         "humanoid_green": "Platformer World",
         "humanoid_tired": "Abandoned Grounds"
       }
@@ -2429,13 +2421,13 @@
       "description": "Você chegou tão longe do ponto de partida.",
       "condition": "Visite as seguintes áreas com as Montanhas Gêmeas vistas à distância: Foliage Estate (Overlook), Flying Fish World (Dream Scene), Mirror Room (Beach), Bleak Future, Saturated Eyeball Zone, Rainy Apartments, Red Sky Cliff (Splash Streetway), Wind Turbine Plateau, Bathhouse",
       "checkbox": {
-        "tw_foliage": "Foliage Estate",
-        "tw_fish": "Flying Fish World",
-        "tw_mirror": "Mirror Room",
+        "tw_foliage": "Foliage Estate (Overlook)",
+        "tw_fish": "Flying Fish World (Dream Scene)",
+        "tw_mirror": "Mirror Room (Beach)",
         "tw_bleak": "Bleak Future",
         "tw_eyeball": "Saturated Eyeball Zone",
         "tw_rainy": "Rainy Apartments",
-        "tw_red": "Red Sky Cliff: Splash Streetway",
+        "tw_red": "Red Sky Cliff (Splash Streetway)",
         "tw_wind": "Wind Turbine Plateau",
         "tw_bathhouse": "Bathhouse"
       }
@@ -2479,7 +2471,7 @@
       "condition": "Visite Jimbo no Giant Desktop e veja o quarto olho mágico no Holiday Hell",
       "checkbox": {
         "jimbo_desktop": "Giant Desktop",
-        "jimbo_holiday": "Ice Cream Islands"
+        "jimbo_holiday": "Holiday Hell"
       }
     },
     "lone_penguin": {
@@ -2498,7 +2490,7 @@
         "honeycomb_world": "Honeycomb World",
         "pink_honeycomb": "Pink Honeycomb",
         "honeybee_laboratory": "Honeybee Laboratory",
-        "honeybee_residence": "Honeybee Residence: Honeybee Skyscraper"
+        "honeybee_residence": "Honeybee Residence"
       }
     },
     "vertigo_parasomnia": {
@@ -2520,7 +2512,7 @@
       "name": "Coletor de Nexus",
       "condition": "Visite o Dark Nexus, o Second Nexus e o Mini-Nexus",
       "checkbox": {
-        "the_second_nexus": "The Second Nexus",
+        "the_second_nexus": "Second Nexus",
         "dark_nexus": "Dark Nexus",
         "mini_nexus": "Mini-Nexus"
       }
@@ -2564,7 +2556,7 @@
       "checkbox": {
         "cyclop_petal_hotel": "Petal Hotel",
         "cyclop_dream_pool": "Dream Pool",
-        "cyclop_silent_sewers": "Silent Sewers: Cyclops' Room",
+        "cyclop_silent_sewers": "Silent Sewers",
         "cyclop_teddy_bear": "Teddy Bear Land",
         "cyclop_red_street": "Red Streetlight World",
         "cyclop_acerola": "Acerola World",
@@ -2609,11 +2601,11 @@
       "name": "Visão das Flores",
       "condition": "Use o efeito Insect próximo às flores localizadas em Flooded Dungeon (Floral Vortex), Travel Hotel, Lost Creek, Snowy Forest (Fairy Hole), Wooden Polycube Ruins",
       "checkbox": {
-        "flowers_vortex": "Flooded Dungeon: Floral Vortex",
+        "flowers_vortex": "Flooded Dungeon (Floral Vortex)",
         "flowers_hotel": "Travel Hotel",
         "flowers_creek": "Lost Creek",
-        "flowers_fairy": "Snowy Forest",
-        "flowers_polycube": "Wooden Polycube Ruins: Icy Garden"
+        "flowers_fairy": "Snowy Forest (Fairy Hole)",
+        "flowers_polycube": "Wooden Polycube Ruins"
       }
     },
     "pudding_world_secrets": {
@@ -2726,11 +2718,7 @@
     "mask_collection": {
       "name": "Especialista em Disfarces",
       "description": "Quem você será hoje?",
-      "condition": "Desbloqueie e veja todas as máscaras sem efeito em uma das Mask Shops (exceto Twintail Girl, Ahogeko, Shadow Mold, Angel Priest, Kīgāru, White Mouse, Black Mouse, Takoyaki Creature e Traffic Cone)",
-      "checkbox": {
-        "mask_shop_s_twintail|mask_shop_s_bird|mask_shop_s_slime|mask_shop_s_guard|mask_shop_paint|mask_shop_uri|mask_shop_yukata|mask_shop_monmon|mask_shop_witch|mask_shop_prov|mask_shop_cat|mask_shop_appu|mask_shop_science|mask_shop_musume|mask_shop_otoko|mask_shop_tv|mask_shop_math|mask_shop_dogboa|mask_shop_huyure|mask_shop_eyeball|mask_shop_chain|mask_shop_fox|mask_shop_seal|mask_shop_candle|mask_shop_barrier|mask_shop_rune": "Mask Shop",
-        "mask_shop_s_twintail_d|mask_shop_s_bird_d|mask_shop_s_slime_d|mask_shop_s_guard_d|mask_shop_paint_d|mask_shop_uri_d|mask_shop_yukata_d|mask_shop_monmon_d|mask_shop_witch_d|mask_shop_prov_d|mask_shop_cat_d|mask_shop_appu_d|mask_shop_science_d|mask_shop_musume_d|mask_shop_otoko_d|mask_shop_tv_d|mask_shop_math_d|mask_shop_dogboa_d|mask_shop_huyure_d|mask_shop_eyeball_d|mask_shop_chain_d|mask_shop_fox_d|mask_shop_seal_d|mask_shop_candle_d|mask_shop_barrier_d|mask_shop_rune_d": "Deluxe Mask Shop"
-      }
+      "condition": "Desbloqueie e veja todas as máscaras sem efeito em uma das Mask Shops (exceto Twintail Girl, Ahogeko, Shadow Mold, Angel Priest, Kīgāru, White Mouse, Black Mouse, Takoyaki Creature e Traffic Cone)"
     },
     "retro_cartridge_game": {
       "name": "Como se fosse 1977!",
@@ -3395,8 +3383,10 @@
       "description": "Velho como o vinho",
       "condition": "Em Japan Town, encontre a Ghost Maiko, descubra algumas criaturas escondidas em uma sala isolada usando o efeito Glasses e interaja com Kanban Otoko e News Man",
       "checkbox": {
-        "japan_town_hotel|japan_town_glasses": "Japan Town: The Hotel",
-        "japan_town_otoko|japan_town_news_man": "Japan Town"
+        "japan_town_hotel": "encontre a Ghost Maiko",
+        "japan_town_glasses": "descubra algumas criaturas escondidas em uma sala isolada usando o efeito Glasses",
+        "japan_town_otoko": "Kanban Otoko",
+        "japan_town_news_man": "News Man"
       }
     },
     "himalayan_lighthouse": {
@@ -3472,14 +3462,14 @@
     },
     "urotsuki_bedrooms": {
       "name": "Síndrome de Urotsuki",
-      "condition": "Visite o quarto de Urotsuki em Urotsuki's Dream Apartments, Drowsy Forest, Mirror Room e Static Labyrinth, e veja os eventos Bleak Future e Vertigo Room",
+      "condition": "Visite o quarto de Urotsuki em Urotsuki's Dream Apartments, Drowsy Forest, Mirror Room e Static Labyrinth, e veja os eventos Bleak Future e Vertigo",
       "checkbox": {
         "urotsukis_dream_apartments": "Urotsuki's Dream Apartments",
         "drowsy_forest_room": "Drowsy Forest",
         "mirror_room": "Mirror Room",
-        "static_doppelganger_room": "Static Labyrinth: Doppelgänger Room",
+        "static_doppelganger_room": "Static Labyrinth",
         "bleak_future_main": "Bleak Future",
-        "vertigo_room": "Urotsuki's Dream Room: Vertigo"
+        "vertigo_room": "Vertigo"
       }
     },
     "2kki_canvas": {
@@ -3869,8 +3859,9 @@
       "description": "Esses flagelos de uma perturbação são monstros ou sinais? Você é uma ferramenta do destino ou uma testemunha de um desastre?",
       "condition": "Motosserre os monstros vermelhos de Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
-        "hexa_pillar_passage_monster|": "Critter Village (Hexagonal Pillar Passage)",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
+        "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
         "pure_white_lands_monster": "Pure White Lands"
@@ -4323,11 +4314,7 @@
     "megusuri_uri_visine": {
       "name": "Vendedor de Colírios",
       "description": "Como esses olhos são muito sensíveis, ele se preocupa muito com seu trabalho",
-      "condition": "Encontre e interaja com Megusuri Uri nas três partes diferentes do Visine World",
-      "checkbox": {
-        "megusuri_uri_visine_1": "Visine World",
-        "megusuri_uri_visine_2|megusuri_uri_visine_3": "Visine World: Eye Shop"
-      }
+      "condition": "Encontre e interaja com Megusuri Uri nas três partes diferentes do Visine World"
     },
     "rgb_passage": {
       "name": "Caminho de Ladrilho RGB",
@@ -4353,14 +4340,14 @@
       "description": "Vamos observar as estrelas!",
       "condition": "Encontre cenários de céu noturno em Twisted Thickets, Foliage Estate, Submerged Communications Area, Shallows of Deceit, Nocturnal Grove, Windswept Scarlet Sands, Planetarium e Tomb of Velleities",
       "checkbox": {
-        "peak": "Twisted Thickets: The Peak",
+        "peak": "Twisted Thickets",
         "foliage_estate_satellite_dish": "Foliage Estate",
         "submerged_communications_area": "Submerged Communications Area",
         "shallows_of_deceit_rooftop": "Shallows of Deceit",
         "nocturnal_grove_boat": "Nocturnal Grove",
         "starry_night": "Windswept Scarlet Sands",
         "star_planetarium": "Planetarium",
-        "tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary"
+        "tomb_of_velleities": "Tomb of Velleities"
       }
     },
     "overgrowth_outlook": {
@@ -4654,7 +4641,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5304,7 +5291,7 @@
     "other_worlds": {
       "name": "Outros mundos",
       "description": "Os acordes do piano levam... a algum lugar...",
-      "condition": "Entre em Young Passage e Microscopic World",
+      "condition": "Entre em Young Passage e Microorganism World",
       "checkbox": {
         "microscopic_world": "Microorganism World",
         "young_passage": "Young Passage"
@@ -5823,8 +5810,8 @@
         "tubes_kondo": "Tubes",
         "purple_crystal": "Memory Graveyard",
         "corrupted_art_gallery_sh_e": "Empty Gallery",
-        "lsd_world": "LSD World (Dynamic)",
-        "kondo_ending_room|kondo_ending_room_2": "Kondo"
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
       }
     },
     "rusty_bubble": {
@@ -6187,11 +6174,11 @@
       "description": "Apreciando a vista o tempo todo",
       "condition": "Caminhe na varanda durante a manhã, dia, tarde, noite e chuva",
       "checkbox": {
-        "balcony_evening": "Balcony",
-        "balcony_day": "Balcony (Day)",
-        "balcony_night": "Balcony (Night)",
-        "balcony_morning": "Balcony (Morning)",
-        "balcony_storm": "Balcony (Storm)"
+        "balcony_evening": "tarde",
+        "balcony_day": "dia",
+        "balcony_night": "noite",
+        "balcony_morning": "manhã",
+        "balcony_storm": "chuva"
       }
     },
     "broken_bridge_monster": {
@@ -6342,8 +6329,8 @@
       "name": "Chefe do Poço",
       "condition": "Veja a pessoa com o pescoço comprido na Mosquies' Village e entre no poço das Dark Lands",
       "checkbox": {
-        "mosquies_village_chief": "Mosquies' Village: The Wickedest Mosquy",
-        "well_dark_lands": "Quiet Path"
+        "mosquies_village_chief": "Mosquies' Village",
+        "well_dark_lands": "Dark Lands"
       }
     },
     "cartoonboy": {
@@ -6956,7 +6943,7 @@
       "condition": "Encontre todas as Sometsuki jovens",
       "checkbox": {
         "emerald_square": "Emerald Square",
-        "emerald_square_some": "Emerald Square: Back Alley",
+        "emerald_square_some": "Back Alley",
         "banquet_hall_some": "Banquet Hall"
       }
     },
@@ -7437,11 +7424,7 @@
     "duality_of_mom": {
       "name": "Mãe...",
       "description": "Eu te amo, por favor, não me machuque.",
-      "condition": "Encontre as versões doce e assustadora da mãe de A.",
-      "checkbox": {
-        "mom_normal": "Nursery Room",
-        "mom_scary": "?"
-      }
+      "condition": "Encontre as versões doce e assustadora da mãe de A."
     },
     "sacred_cats": {
       "name": "Gatos Sagrados",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -4641,7 +4641,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4642,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Health Drinks",
-      "condition": "Find all 3 vending machines and buy a drink from each one"
+      "condition": "Buy a drink from all 3 vending machines in Dense Woods A, Hell, and Docks A",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Window",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Miniature Singularity",
-      "condition": "Find and interact with All 5 Black Hole Girls in Río's worlds. If you have already done so previously, you must visit the area where you found them."
+      "condition": "Interact with all 5 Black Hole Girls in Río's worlds, or revisit the areas where they appear (Decrepit Dwellings, Verdant Promenade, Forgotten Megalopolis, Tomb of Velleities: Lunar Sanctuary, Luminous Lake: Dragon's Peak)",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Escape from the Show",
@@ -1099,7 +1111,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1259,11 +1281,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1456,7 +1479,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2345,7 +2369,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3826,9 +3858,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4609,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5772,7 +5805,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5806,7 +5847,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6892,7 +6941,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6954,7 +7008,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7306,11 +7364,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -372,18 +372,14 @@
       "description": "Трое из вида.",
       "condition": "Interact with Nopperabou Ghost and Fleebie while using the Spirit Headband effect and stab Follony with the Kitchen Knife effect",
       "checkbox": {
-        "ghostly_nopp": "Dark World",
-        "ghostly_follony": "Sewers",
-        "ghostly_fleebie": "Ghost World"
+        "ghostly_nopp": "Nopperabou Ghost",
+        "ghostly_follony": "stab Follony with the Kitchen Knife effect",
+        "ghostly_fleebie": "Fleebie"
       }
     },
     "wilderness_fan": {
       "name": "Исследователь пустыни",
-      "condition": "Посетите все зоны Пустыни.",
-      "checkbox": {
-        "wilderness_50|wilderness_51|wilderness_52|wilderness_53|wilderness_54|wilderness_55|wilderness_56|wilderness_57|wilderness_58|wilderness_59|wilderness_60|wilderness_61|wilderness_62|wilderness_63|wilderness_64": "Wilderness",
-        "wilderness_65": "Hot Spring House"
-      }
+      "condition": "Посетите все зоны Пустыни."
     },
     "dave_death": {
       "name": "Dave-y Jones Locker",
@@ -881,7 +877,7 @@
         "downfall_garden_b": "Downfall Garden B",
         "sparkling_dimension_b": "Sparkling Dimension B",
         "opal_ruins_b": "Opal Ruins B",
-        "fuchsia_suburbs_b": "Originator Garden: Fuchsia Suburbs B"
+        "fuchsia_suburbs_b": "Fuchsia Suburbs B"
       }
     },
     "survivor": {
@@ -1004,7 +1000,7 @@
         "01_fluorescent_halls": "Fluorescent Halls",
         "01_corrupted_love_world": "Corrupted Love World",
         "01_winter_valley": "Winter Valley",
-        "01_bright_forest": "Bright Forest: Rainbow Ruins"
+        "01_bright_forest": "Bright Forest"
       }
     },
     "tetrapod": {
@@ -1191,11 +1187,11 @@
         "digital_hand_hub": "Stone World",
         "urban_street_area": "Urban Street Area",
         "the_docks": "The Docks",
-        "zalgo": "Magnet Room: Zalgo's Room?",
-        "white_mushroom_field": "Mushroom World: White Mushroom Field",
-        "crimson_labyrinth_mountains": "Crimson Labyrinth",
+        "zalgo": "Magnet Room (Zalgo's Room?)",
+        "white_mushroom_field": "Mushroom World (White Mushroom Field)",
+        "crimson_labyrinth_mountains": "Crimson Labyrinth (Red Mountains)",
         "color_cubes_world": "Color Cubes World",
-        "octagonal_grid_hub_passage": "Octagonal Grid Hub",
+        "octagonal_grid_hub_passage": "Octagonal Grid Hub (Broken Passage)",
         "obentou_world": "Obentou World",
         "entropy_dungeon": "Entropy Dungeon",
         "rainbow_towers": "Rainbow Towers"
@@ -1289,7 +1285,8 @@
       "checkbox": {
         "garden_world_clock_pole": "Garden World (ночь)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1315,11 +1312,7 @@
     "plaza": {
       "name": "Гидроплощадь",
       "description": "Это не город, Это площадь.",
-      "condition": "Обследуйте Poseidon Plaza.",
-      "checkbox": {
-        "plaza_1|plaza_3|plaza_4|plaza_5": "Poseidon Plaza",
-        "plaza_2": "Deep Red Wilds"
-      }
+      "condition": "Обследуйте Poseidon Plaza."
     },
     "robot": {
       "name": "Хранилище",
@@ -1335,10 +1328,11 @@
       "description": "Самый Важный Аппарат",
       "condition": "Используйте телефон к Urotsuki's Dream Apartments во всех 8 локациях: Aquatic Cube City, Fossil Lake, Sugar Road, Underground Garage, Water Reclamation Facility, Dark Museum, Dark Warehouse и Parking Zone.",
       "checkbox": {
-        "phone_aquatic_cube_city|phone_fossil_lake": "Fossil Lake",
+        "phone_aquatic_cube_city": "Aquatic Cube City",
+        "phone_fossil_lake": "Fossil Lake",
         "phone_sugar_road": "Sugar Road",
         "phone_underground_garage": "Underground Garage",
-        "phone_water_reclamation_facility": "Water Reclamation Facility: Shutter Alley",
+        "phone_water_reclamation_facility": "Water Reclamation Facility",
         "phone_dark_museum": "Dark Museum",
         "phone_dark_warehouse": "Dark Warehouse",
         "phone_parking_zone": "Parking Zone"
@@ -1472,9 +1466,10 @@
     "helmet_girl": {
       "name": "Блести",
       "description": "Встретимся на тёмной стороне луны.",
-      "condition": "Найдите Девочку со шлемом в Square-Square World, Её квартире, и на Moonlit Purple Balcony.",
+      "condition": "Найдите Девочку со шлемом в Square-Square World, Её квартире, и на Moonlit Purple Balcony",
       "checkbox": {
-        "helmet_girl_moonlit_balcony|helmet_girl_apartment": "Flying Fish World",
+        "helmet_girl_moonlit_balcony": "Moonlit Purple Balcony",
+        "helmet_girl_apartment": "Её квартире",
         "helmet_girl_square2_world": "Square-Square World"
       }
     },
@@ -1699,15 +1694,15 @@
       "checkbox": {
         "uro_atlantis": "Atlantis",
         "uro_tapir_place": "Tapir-San's Place",
-        "uro_cloning_room": "Red Brick Maze: Cloning Room",
-        "uro_bleak_future": "Bleak Future",
+        "uro_cloning_room": "Giant Cloning Room",
+        "uro_bleak_future": "Urotsuki's Dream Apartments",
         "uro_pinwheel_path": "Closet Pinwheel Path",
         "uro_red_sky_cliff": "Red Sky Cliff",
         "uro_despair_road": "Despair Road",
         "uro_killed_head": "Head World",
         "uro_static_noise_hell": "Static Noise Hell",
         "uro_colorless_valley": "Colorless Valley",
-        "uro_spear_tribe_world": "Spear Tribe World: Overgrown Stone Area"
+        "uro_spear_tribe_world": "Spear Tribe World"
       }
     },
     "blossoming_brooch": {
@@ -1918,13 +1913,7 @@
     "gb_memories": {
       "name": "Воспоминания о GB",
       "description": "Помнишь?",
-      "condition": "Узрите все секреты Monochrome GB World и сядьте на скамейку в конце NES Glitch Tunnel.",
-      "checkbox": {
-        "gb_change_color|gb_house_secret": "Monochrome GB World",
-        "gb_flower_pot": "Monochrome GB World: GB Well",
-        "nes_tunnel_bench": "NES Glitch Tunnel",
-        "gb_forest_event": "Sketch Plains"
-      }
+      "condition": "Узрите все секреты Monochrome GB World и сядьте на скамейку в конце NES Glitch Tunnel."
     },
     "bunny_cocktail": {
       "name": "Заячий коктейль",
@@ -2271,7 +2260,7 @@
       "description": "Два лучше, чем один!",
       "condition": "Доберитесь до Witch's House в Love Lodge, места, где находится замёрзшая Ведьма Милосердия, и найдите картину в Hatred Palace.",
       "checkbox": {
-        "love_witch_house": "Love Lodge",
+        "love_witch_house": "Witch's House в Love Lodge",
         "frozen_charity_witch": "Snowy Suburbs",
         "painting_hatred_palace": "Hatred Palace"
       }
@@ -2381,7 +2370,10 @@
       "description": "Кружится, кружится, кружится...",
       "condition": "Побывайте в 6 мирах на изображении, не пользуясь телепортом в Oriental Pub.",
       "checkbox": {
-        "humanoid_angry|humanoid_crying|humanoid_happy|humanoid_shocked": "Ice Cream Islands",
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
         "humanoid_green": "Platformer World",
         "humanoid_tired": "Abandoned Grounds"
       }
@@ -2429,13 +2421,13 @@
       "description": "Тобой пройдено уже так много от того, где тебе пришлось начинать.",
       "condition": "Посетите следующие зоны с видом на Горы-близнецы: Foliage Estate (Overlook), Flying Fish World (Dream Scene), Mirror Room (Beach), Bleak Future, Saturated Eyeball Zone, Rainy Apartments, Red Sky Cliff (Splash Streetway), Wind Turbine Plateau, Bathhouse",
       "checkbox": {
-        "tw_foliage": "Foliage Estate",
-        "tw_fish": "Flying Fish World",
-        "tw_mirror": "Mirror Room",
+        "tw_foliage": "Foliage Estate (Overlook)",
+        "tw_fish": "Flying Fish World (Dream Scene)",
+        "tw_mirror": "Mirror Room (Beach)",
         "tw_bleak": "Bleak Future",
         "tw_eyeball": "Saturated Eyeball Zone",
         "tw_rainy": "Rainy Apartments",
-        "tw_red": "Red Sky Cliff: Splash Streetway",
+        "tw_red": "Red Sky Cliff (Splash Streetway)",
         "tw_wind": "Wind Turbine Plateau",
         "tw_bathhouse": "Bathhouse"
       }
@@ -2479,7 +2471,7 @@
       "condition": "Встретьтесь с Джимбо на Giant Desktop и загляните в четвёртую дыру в Holiday Hell.",
       "checkbox": {
         "jimbo_desktop": "Giant Desktop",
-        "jimbo_holiday": "Ice Cream Islands"
+        "jimbo_holiday": "Holiday Hell"
       }
     },
     "lone_penguin": {
@@ -2498,7 +2490,7 @@
         "honeycomb_world": "Honeycomb World",
         "pink_honeycomb": "Pink Honeycomb",
         "honeybee_laboratory": "Honeybee Laboratory",
-        "honeybee_residence": "Honeybee Residence: Honeybee Skyscraper"
+        "honeybee_residence": "Honeybee Residence"
       }
     },
     "vertigo_parasomnia": {
@@ -2520,7 +2512,7 @@
       "name": "Собиратель Нексусов",
       "condition": "Побывайте в Dark Nexus, Second Nexus, и Mini-Nexus.",
       "checkbox": {
-        "the_second_nexus": "The Second Nexus",
+        "the_second_nexus": "Second Nexus",
         "dark_nexus": "Dark Nexus",
         "mini_nexus": "Mini-Nexus"
       }
@@ -2564,7 +2556,7 @@
       "checkbox": {
         "cyclop_petal_hotel": "Petal Hotel",
         "cyclop_dream_pool": "Dream Pool",
-        "cyclop_silent_sewers": "Silent Sewers: Cyclops' Room",
+        "cyclop_silent_sewers": "Silent Sewers",
         "cyclop_teddy_bear": "Teddy Bear Land",
         "cyclop_red_street": "Red Streetlight World",
         "cyclop_acerola": "Acerola World",
@@ -2607,13 +2599,13 @@
     },
     "flower_vision": {
       "name": "Цветочное видение",
-      "condition": "Используйте эффект Жука рядом с цветами в Flooded Dungeon (Цветочная дыра), Travel Hotel, Lost Creek, Snowy Forest (Пещера феи), Wooden Polycube Ruins.",
+      "condition": "Используйте эффект Жука рядом с цветами в Flooded Dungeon (Цветочная дыра), Travel Hotel, Lost Creek, Snowy Forest (Пещера феи), Wooden Polycube Ruins",
       "checkbox": {
-        "flowers_vortex": "Flooded Dungeon: Floral Vortex",
+        "flowers_vortex": "Flooded Dungeon (Цветочная дыра)",
         "flowers_hotel": "Travel Hotel",
         "flowers_creek": "Lost Creek",
-        "flowers_fairy": "Snowy Forest",
-        "flowers_polycube": "Wooden Polycube Ruins: Icy Garden"
+        "flowers_fairy": "Snowy Forest (Пещера феи)",
+        "flowers_polycube": "Wooden Polycube Ruins"
       }
     },
     "pudding_world_secrets": {
@@ -2726,11 +2718,7 @@
     "mask_collection": {
       "name": "Мастер маскировки",
       "description": "Кем будешь сегодня?",
-      "condition": "Разблокируйте и просмотрите все не связанные с эффектами маски в одном из Mask Shop (помимо Девочки с хвостиками, Ахогеко, Теневого Сгустка, Кигяру, Белой мыши, Чёрной мыши, Существа Такояки, Angel Priest и Дорожного конуса).",
-      "checkbox": {
-        "mask_shop_s_twintail|mask_shop_s_bird|mask_shop_s_slime|mask_shop_s_guard|mask_shop_paint|mask_shop_uri|mask_shop_yukata|mask_shop_monmon|mask_shop_witch|mask_shop_prov|mask_shop_cat|mask_shop_appu|mask_shop_science|mask_shop_musume|mask_shop_otoko|mask_shop_tv|mask_shop_math|mask_shop_dogboa|mask_shop_huyure|mask_shop_eyeball|mask_shop_chain|mask_shop_fox|mask_shop_seal|mask_shop_candle|mask_shop_barrier|mask_shop_rune": "Mask Shop",
-        "mask_shop_s_twintail_d|mask_shop_s_bird_d|mask_shop_s_slime_d|mask_shop_s_guard_d|mask_shop_paint_d|mask_shop_uri_d|mask_shop_yukata_d|mask_shop_monmon_d|mask_shop_witch_d|mask_shop_prov_d|mask_shop_cat_d|mask_shop_appu_d|mask_shop_science_d|mask_shop_musume_d|mask_shop_otoko_d|mask_shop_tv_d|mask_shop_math_d|mask_shop_dogboa_d|mask_shop_huyure_d|mask_shop_eyeball_d|mask_shop_chain_d|mask_shop_fox_d|mask_shop_seal_d|mask_shop_candle_d|mask_shop_barrier_d|mask_shop_rune_d": "Deluxe Mask Shop"
-      }
+      "condition": "Разблокируйте и просмотрите все не связанные с эффектами маски в одном из Mask Shop (помимо Девочки с хвостиками, Ахогеко, Теневого Сгустка, Кигяру, Белой мыши, Чёрной мыши, Существа Такояки, Angel Priest и Дорожного конуса)."
     },
     "retro_cartridge_game": {
       "name": "Прямо как в 1977!",
@@ -3395,8 +3383,10 @@
       "description": "Old like wine",
       "condition": "In Japan Town, find the Ghost Maiko, discover some creatures hidden in an isolated room by using the Glasses effect, and interact with Kanban Otoko and News Man",
       "checkbox": {
-        "japan_town_hotel|japan_town_glasses": "Japan Town: The Hotel",
-        "japan_town_otoko|japan_town_news_man": "Japan Town"
+        "japan_town_hotel": "find the Ghost Maiko",
+        "japan_town_glasses": "discover some creatures hidden in an isolated room by using the Glasses effect",
+        "japan_town_otoko": "Kanban Otoko",
+        "japan_town_news_man": "News Man"
       }
     },
     "himalayan_lighthouse": {
@@ -3472,14 +3462,14 @@
     },
     "urotsuki_bedrooms": {
       "name": "Urotsuki's Syndrome",
-      "condition": "Visit Urotsuki's room in Urotsuki's Dream Apartments, Drowsy Forest, Mirror Room and Static Labyrinth, and see the Bleak Future and Vertigo Room events",
+      "condition": "Visit Urotsuki's room in Urotsuki's Dream Apartments, Drowsy Forest, Mirror Room and Static Labyrinth, and see the Bleak Future and Vertigo events",
       "checkbox": {
         "urotsukis_dream_apartments": "Urotsuki's Dream Apartments",
         "drowsy_forest_room": "Drowsy Forest",
         "mirror_room": "Mirror Room",
-        "static_doppelganger_room": "Static Labyrinth: Doppelgänger Room",
+        "static_doppelganger_room": "Static Labyrinth",
         "bleak_future_main": "Bleak Future",
-        "vertigo_room": "Urotsuki's Dream Room: Vertigo"
+        "vertigo_room": "Vertigo"
       }
     },
     "2kki_canvas": {
@@ -3869,7 +3859,8 @@
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
       "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4323,11 +4314,7 @@
     "megusuri_uri_visine": {
       "name": "Eye Drops Vendor",
       "description": "These eyes are very sensitive so he cares a lot about his work",
-      "condition": "Find and interact with Megusuri Uri in the three different parts of Visine World",
-      "checkbox": {
-        "megusuri_uri_visine_1": "Visine World",
-        "megusuri_uri_visine_2|megusuri_uri_visine_3": "Visine World: Eye Shop"
-      }
+      "condition": "Find and interact with Megusuri Uri in the three different parts of Visine World"
     },
     "rgb_passage": {
       "name": "RGB Tile Path",
@@ -4353,14 +4340,14 @@
       "description": "Let's go stargazing!",
       "condition": "Find night sky sceneries in Twisted Thickets, Foliage Estate, Submerged Communications Area, Shallows of Deceit, Nocturnal Grove, Windswept Scarlet Sands, Planetarium, and Tomb of Velleities",
       "checkbox": {
-        "peak": "Twisted Thickets: The Peak",
+        "peak": "Twisted Thickets",
         "foliage_estate_satellite_dish": "Foliage Estate",
         "submerged_communications_area": "Submerged Communications Area",
         "shallows_of_deceit_rooftop": "Shallows of Deceit",
         "nocturnal_grove_boat": "Nocturnal Grove",
         "starry_night": "Windswept Scarlet Sands",
         "star_planetarium": "Planetarium",
-        "tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary"
+        "tomb_of_velleities": "Tomb of Velleities"
       }
     },
     "overgrowth_outlook": {
@@ -4654,7 +4641,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5823,8 +5810,8 @@
         "tubes_kondo": "Tubes",
         "purple_crystal": "Memory Graveyard",
         "corrupted_art_gallery_sh_e": "Empty Gallery",
-        "lsd_world": "LSD World (Dynamic)",
-        "kondo_ending_room|kondo_ending_room_2": "Kondo"
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
       }
     },
     "rusty_bubble": {
@@ -6342,8 +6329,8 @@
       "name": "Chief of the Well",
       "condition": "See the person with the long neck in the Mosquies' Village and enter in the well of the Dark Lands",
       "checkbox": {
-        "mosquies_village_chief": "Mosquies' Village: The Wickedest Mosquy",
-        "well_dark_lands": "Quiet Path"
+        "mosquies_village_chief": "Mosquies' Village",
+        "well_dark_lands": "Dark Lands"
       }
     },
     "cartoonboy": {
@@ -6956,7 +6943,7 @@
       "condition": "Encounter all the young Sometsuki",
       "checkbox": {
         "emerald_square": "Emerald Square",
-        "emerald_square_some": "Emerald Square: Back Alley",
+        "emerald_square_some": "Back Alley",
         "banquet_hall_some": "Banquet Hall"
       }
     },
@@ -7437,11 +7424,7 @@
     "duality_of_mom": {
       "name": "Mom...",
       "description": "I love you, please don't hurt me.",
-      "condition": "Find both the sweet and scary versions of A's mom",
-      "checkbox": {
-        "mom_normal": "Nursery Room",
-        "mom_scary": "?"
-      }
+      "condition": "Find both the sweet and scary versions of A's mom"
     },
     "sacred_cats": {
       "name": "Sacred Cats",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4641,7 +4641,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Sağlık İçecekleri",
-      "condition": "Üç otomatın tamamını bul ve hepsinden bir içecek satın al"
+      "condition": "Üç otomatın tamamını bul ve hepsinden bir içecek satın al",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Pencere",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Minyatür Tekillik",
-      "condition": "Río'nun dünyalarındaki 5 Kara Delik Kız'ın tamamını bul ve etkileşime geç. Eğer önceden bunu yaptıysan, onları bulduğun alanı tekrar ziyaret etmen gerekiyor."
+      "condition": "Río'nun dünyalarındaki 5 Kara Delik Kız'ın tamamını bul ve etkileşime geç. Eğer önceden bunu yaptıysan, onları bulduğun alanı tekrar ziyaret etmen gerekiyor.",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Gösteriden Kurtul",
@@ -1095,7 +1107,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1255,11 +1277,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1452,7 +1475,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2341,7 +2365,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3822,9 +3854,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4605,7 +4638,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5768,7 +5801,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5802,7 +5843,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6888,7 +6937,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6950,7 +7004,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7302,11 +7360,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -1107,7 +1107,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4638,7 +4638,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -245,7 +245,12 @@
     },
     "bottles": {
       "name": "Health Drinks",
-      "condition": "Tìm hết 3 máy bán nước và mua nước từ mỗi máy"
+      "condition": "Tìm hết 3 máy bán nước và mua nước từ mỗi máy",
+      "checkbox": {
+        "jihanki_dense_woods": "Dense Woods A",
+        "jihanki_hell": "Hell",
+        "jihanki_docks": "Docks A"
+      }
     },
     "mado": {
       "name": "Window",
@@ -635,7 +640,14 @@
     },
     "singularity": {
       "name": "Miniature Singularity",
-      "condition": "Tìm và tương tác với tất cả 5 Black Hole Girls trong map của Río. Nếu bạn đã hoàn thành từ trước, hãy quay về thăm nơi bạn tìm được họ."
+      "condition": "Tìm và tương tác với tất cả 5 Black Hole Girls trong map của Río. Nếu bạn đã hoàn thành từ trước, hãy quay về thăm nơi bạn tìm được họ.",
+      "checkbox": {
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
+        "b_h_g_verdant_promenade": "Verdant Promenade",
+        "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
+      }
     },
     "circus_lesser": {
       "name": "Escape from the Show",
@@ -1099,7 +1111,17 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu types 8-15 and 25. For any you have already obtained, return to the area where you originally found them."
+      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "checkbox": {
+        "menu_theme_8": "Hidden Shoal",
+        "menu_theme_9": "Forest Pier",
+        "menu_theme_10": "Planetarium",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
+        "menu_theme_12": "Rose Church",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
+        "menu_theme_25": "Viridian Wetlands"
+      }
     },
     "scared_octopus": {
       "name": "Scared Octopus",
@@ -1259,11 +1281,12 @@
     "clock_pole": {
       "name": "Punctuality",
       "description": "Always be punctual!",
-      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (2), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
+      "condition": "Find and approach the clock poles in Garden World (night), Blue Forest, Botanical Garden (outdoors, passage), Sculpture Park, Twilight Park, Monochrome School, Sunrise Road, Pure White Lands and Critter Village",
       "checkbox": {
         "garden_world_clock_pole": "Garden World (night)",
         "blue_forest_clock_pole": "Blue Forest",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden (2)",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
         "twilight_park_clock_pole": "Twilight Park",
         "monochrome_school_clock_pole": "Monochrome School",
@@ -1456,7 +1479,8 @@
       "condition": "Interact with (or enter the room containing) the trees of Mountaintop Ruins, Blood Cell Sea (including its Qliphothic state), Graffiti Maze, Shinto Shrine, Azure Garden, Scenic Outlook, and Evergreen Woods",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea (including its Qliphothic state)",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
         "shinto_shrine_tree": "Shinto Shrine",
         "scenic_outlook_tree": "Scenic Outlook",
@@ -2345,7 +2369,15 @@
     "carousel_oriental": {
       "name": "Carousel",
       "description": "Round and round and round...",
-      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub"
+      "condition": "Visit the 6 worlds depicted without using the warp from Oriental Pub (Test Facility, Holiday Hell, Ice Cream Islands, Tribulation Complex, Platformer World, Abandoned Grounds)",
+      "checkbox": {
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
+        "humanoid_green": "Platformer World",
+        "humanoid_tired": "Abandoned Grounds"
+      }
     },
     "brh_event": {
       "name": "Blood Red RNG",
@@ -3826,9 +3858,10 @@
     "red_monsters_qxy": {
       "name": "Nightmare Spasms",
       "description": "Are these scourges of a perturbation monsters or signs? Are you a tool of fate or a witness to a disaster?",
-      "condition": "Chainsaw the red monsters in Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
+      "condition": "Chainsaw the red monsters in Wooded Lakeside A, Wooded Lakeside B, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "Wooded Lakeside",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
         "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
         "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
@@ -4609,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5772,7 +5805,15 @@
     "kondo": {
       "name": "Kondo",
       "description": "Yes, it's him.",
-      "condition": "See Kondo in all places she appears"
+      "condition": "See Kondo in Glitch World, Tubes, Memory Graveyard, Empty Gallery, LSD World, Chaos",
+      "checkbox": {
+        "glitch_world_kondo": "Glitch World",
+        "tubes_kondo": "Tubes",
+        "purple_crystal": "Memory Graveyard",
+        "corrupted_art_gallery_sh_e": "Empty Gallery",
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
+      }
     },
     "rusty_bubble": {
       "name": "Rusty Bubble",
@@ -5806,7 +5847,15 @@
     "lil_tsuki": {
       "name": "Li'l Itsuki",
       "description": "The past forms the future.",
-      "condition": "See Itsuki's younger self in all places he appears"
+      "condition": "See Itsuki's younger self in School World, Corrupted School World, Glacier, Space Party, Doodle World, Art Gallery",
+      "checkbox": {
+        "lil_tsuki_school": "School World",
+        "lil_tsuki_corrupted": "Corrupted School World",
+        "lil_tsuki_snow": "Glacier",
+        "lil_tsuki_yellow_crystal": "Space Party",
+        "lil_tsuki_doodle": "Doodle World",
+        "lil_tsuki_art": "Art Gallery"
+      }
     },
     "silent_laughter": {
       "name": "𝐍𝐨𝐭",
@@ -6892,7 +6941,12 @@
     "young_sometsuki": {
       "name": "Little Disgrace",
       "description": "What is it? What is it that you have done?",
-      "condition": "Encounter all the young Sometsuki"
+      "condition": "Encounter all the young Sometsuki in Emerald Square (including Back Alley) and Banquet Hall",
+      "checkbox": {
+        "emerald_square": "Emerald Square",
+        "emerald_square_some": "Back Alley",
+        "banquet_hall_some": "Banquet Hall"
+      }
     },
     "creature_dark_forest": {
       "name": "Lake Dwellers",
@@ -6954,7 +7008,11 @@
     "eternal_love": {
       "name": "Eternal Love",
       "description": "\"I will follow you to the ends of the earth,\nAnd there I will give you a kiss of rebirth.\"",
-      "condition": "Go on a date with Alesandre in the places where you meet him"
+      "condition": "Go on a date with Alesandre in Flooded Garden and Rave Hall",
+      "checkbox": {
+        "flooded_garden_kiss": "Flooded Garden",
+        "rave_rooftop_lovers": "Rave Hall"
+      }
     },
     "lantern_piers": {
       "name": "Lanterns at Sunset",
@@ -7306,11 +7364,11 @@
     },
     "deep_forest": {
       "name": "Secrets and Branches",
-      "condition": "Visit the Deep Forest A, B, and C",
+      "condition": "Visit Deep Forest A, Deep Forest B, and Deep Forest C",
       "checkbox": {
         "deep_forest_a_1|deep_forest_a_2": "Deep Forest A",
-        "deep_forest_b_1|deep_forest_b_2": "B",
-        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "C"
+        "deep_forest_b_1|deep_forest_b_2": "Deep Forest B",
+        "deep_forest_c_1|deep_forest_c_2|deep_forest_c_3": "Deep Forest C"
       }
     },
     "tsh_gothic_dress_effect": {

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -1111,7 +1111,7 @@
     },
     "egg": {
       "name": "Memories of the Chromatic Nest",
-      "condition": "Obtain menu themes 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 8-15 and 25 in Hidden Shoal, Forest Pier, Planetarium, Industrial Maze, Rose Church, Bioluminescent Cavern, Depths, and Viridian Wetlands. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
@@ -4642,7 +4642,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -372,18 +372,14 @@
       "description": "各显神通。",
       "condition": "装备△头巾与Nopperabou Ghost和Fleebie互动，并刀掉Follony。",
       "checkbox": {
-        "ghostly_nopp": "黑暗世界",
-        "ghostly_follony": "下水道",
-        "ghostly_fleebie": "混凝土废墟"
+        "ghostly_nopp": "Nopperabou Ghost",
+        "ghostly_follony": "Follony",
+        "ghostly_fleebie": "Fleebie"
       }
     },
     "wilderness_fan": {
       "name": "荒野求生专家",
-      "condition": "探索荒野的每一处。",
-      "checkbox": {
-        "wilderness_50|wilderness_51|wilderness_52|wilderness_53|wilderness_54|wilderness_55|wilderness_56|wilderness_57|wilderness_58|wilderness_59|wilderness_60|wilderness_61|wilderness_62|wilderness_63|wilderness_64": "荒野",
-        "wilderness_65": "温泉屋"
-      }
+      "condition": "探索荒野的每一处。"
     },
     "dave_death": {
       "name": "戴维琼斯的箱子",
@@ -638,7 +634,7 @@
       "condition": "造访地底湖、树林空间与石跡",
       "checkbox": {
         "underground_lake": "地底湖",
-        "cliffside_woods": "樹林空間",
+        "cliffside_woods": "树林空间",
         "radiant_stones_pathway": "石跡"
       }
     },
@@ -646,11 +642,11 @@
       "name": "微型黑洞",
       "condition": "在Río的世界里，找到所有5个黑洞女孩并与其互动。若已互动过，则必须抵达每位女孩的原本位置。",
       "checkbox": {
-        "b_h_g_decrepit_dwellings": "集合住宅",
+        "b_h_g_decrepit_dwellings": "Decrepit Dwellings",
         "b_h_g_verdant_promenade": "Verdant Promenade",
         "b_h_g_forgotten_megalopolis": "Forgotten Megalopolis",
-        "b_h_g_tomb_of_velleities": "Butterfly：最奥",
-        "b_h_g_dragons_peak": "夢徨龍リオドリムス"
+        "b_h_g_tomb_of_velleities": "Tomb of Velleities: Lunar Sanctuary",
+        "b_h_g_dragons_peak": "Luminous Lake: Dragon's Peak"
       }
     },
     "circus_lesser": {
@@ -746,9 +742,9 @@
       "name": "神仙书虫",
       "condition": "造访梦幻图书馆、无尽图书馆、魔法图书馆",
       "checkbox": {
-        "library": "Library",
-        "infinite_library": "Infinite Library",
-        "mystery_library": "魔法図書館"
+        "library": "梦幻图书馆",
+        "infinite_library": "无尽图书馆",
+        "mystery_library": "魔法图书馆"
       }
     },
     "cosmic_cube": {
@@ -878,10 +874,10 @@
       "name": "B位面",
       "condition": "造访呕吐庭B、闪烁通道B、辩论嫌忌B、反富裕B",
       "checkbox": {
-        "downfall_garden_b": "嘔吐庭：血反吐エリア",
-        "sparkling_dimension_b": "黒潰れ：街灯と木のエリア",
-        "opal_ruins_b": "ミサロジー：陸（深層側）",
-        "fuchsia_suburbs_b": "反富裕：始祖庭側"
+        "downfall_garden_b": "呕吐庭B",
+        "sparkling_dimension_b": "闪烁通道B",
+        "opal_ruins_b": "辩论嫌忌B",
+        "fuchsia_suburbs_b": "反富裕B"
       }
     },
     "survivor": {
@@ -961,7 +957,7 @@
     "dream_fishing": {
       "name": "渔之乐",
       "description": "这条挺别致的",
-      "condition": "抵达 地下的海, 鱼骨, Fish World, 鲭沙漠, 寿司世界, 飞鱼世界, 石影, Streetlight Docks, Depths,和 Bioluminescent Caverns",
+      "condition": "抵达 地下的海, 鱼骨, Fish World, 鲭沙漠, 寿司世界, 飞鱼世界, 石影, Streetlight Docks, Depths,和 Bioluminescent Cavern",
       "checkbox": {
         "ocean_subsurface": "Ocean Subsurface",
         "rotten_fish_lake": "Rotten Fish Lake",
@@ -971,8 +967,8 @@
         "fish_f_f_world": "Flying Fish World",
         "fish_lamplit": "Lamplit Stones",
         "fish_streetlight": "Streetlight Docks",
-        "fish_depths": "みなぞこ",
-        "fish_bioluminescent": "夜花草"
+        "fish_depths": "Depths",
+        "fish_bioluminescent": "Bioluminescent Cavern"
       }
     },
     "decrepit_smile": {
@@ -1003,18 +999,13 @@
         "01_digital_forest_1|01_digital_forest_2": "Digital Forest",
         "01_fluorescent_halls": "Fluorescent Halls",
         "01_corrupted_love_world": "Corrupted Love World",
-        "01_winter_valley": "深層：雪降る森エリア",
-        "01_bright_forest": "虹遺跡"
+        "01_winter_valley": "Winter Valley",
+        "01_bright_forest": "Bright Forest"
       }
     },
     "tetrapod": {
       "name": "消波块",
-      "condition": "踏遍海滨沙滩的每片区域",
-      "checkbox": {
-        "realistic_beach_1|realistic_beach_2|realistic_beach_3|realistic_beach_4|realistic_beach_5|realistic_beach_6": "Realistic Beach",
-        "realistic_beach_7|realistic_beach_8|realistic_beach_9|realistic_beach_10": "消波ブロック内部",
-        "realistic_beach_11|realistic_beach_12": "消波ブロック内部奥"
-      }
+      "condition": "踏遍海滨沙滩的每片区域"
     },
     "stellar_graveyard": {
       "name": "星耀墓场",
@@ -1125,11 +1116,10 @@
         "menu_theme_8": "Hidden Shoal",
         "menu_theme_9": "Forest Pier",
         "menu_theme_10": "Planetarium",
-        "b_h_g_antiquated_resthouse": "蒸気工場",
+        "b_h_g_antiquated_resthouse": "Industrial Maze",
         "menu_theme_12": "Rose Church",
-        "menu_theme_13": "夜花草",
-        "menu_theme_14": "みなぞこ",
-        "menu_theme_15": "すいそう",
+        "menu_theme_13": "Bioluminescent Cavern",
+        "menu_theme_14|menu_theme_15": "Depths",
         "menu_theme_25": "Viridian Wetlands"
       }
     },
@@ -1197,12 +1187,12 @@
         "digital_hand_hub": "Stone World",
         "urban_street_area": "Urban Street Area",
         "the_docks": "The Docks",
-        "zalgo": "うつむき部屋",
-        "white_mushroom_field": "裏きのこ",
-        "crimson_labyrinth_mountains": "溶岩山",
+        "zalgo": "Magnet Room (Zalgo's Room?)",
+        "white_mushroom_field": "Mushroom World (White Mushroom Field)",
+        "crimson_labyrinth_mountains": "Crimson Labyrinth (Red Mountains)",
         "color_cubes_world": "Color Cubes World",
-        "octagonal_grid_hub_passage": "Octagonal Grid Hub",
-        "obentou_world": "吐き気",
+        "octagonal_grid_hub_passage": "Octagonal Grid Hub (Broken Passage)",
+        "obentou_world": "Obentou World",
         "entropy_dungeon": "Entropy Dungeon",
         "rainbow_towers": "Rainbow Towers"
       }
@@ -1256,21 +1246,7 @@
     "flying_fish_world": {
       "name": "我们与他们",
       "description": "到最后都是在原地打转",
-      "condition": "造访飞鱼世界的所有区域",
-      "checkbox": {
-        "flying_fish_world_1": "夕焼け",
-        "flying_fish_world_2|flying_fish_world_3": "待ち人",
-        "flying_fish_world_4|flying_fish_world_5": "正体不明",
-        "flying_fish_world_6": "古き良きテレビ",
-        "flying_fish_world_7": "頭蓋岩",
-        "flying_fish_world_8|flying_fish_world_14": "パース",
-        "flying_fish_world_9": "Flying Fish World",
-        "flying_fish_world_10": "怒りと血涙",
-        "flying_fish_world_11": "白い部屋",
-        "flying_fish_world_12": "夜景ベランダ",
-        "flying_fish_world_13": "鉢植え部屋：水槽と本棚のある鉢植え部屋",
-        "flying_fish_world_15": "時計"
-      }
+      "condition": "造访飞鱼世界的所有区域"
     },
     "sacred_crypt": {
       "name": "起源之梦",
@@ -1296,10 +1272,10 @@
       "description": "她与某人有种奇怪的相似之处...",
       "condition": "在以下每个地方找到神秘女仆并与其互动: 医院, 空中公园, 铁轨世界, 施工支架世界",
       "checkbox": {
-        "m_m_hospital": "病院",
-        "m_m_sky_kingdom": "空中公園",
-        "m_m_train_tracks": "廃線：線路エリア",
-        "m_m_construction_frame": "Construction Frame Building"
+        "m_m_hospital": "医院",
+        "m_m_sky_kingdom": "空中公园",
+        "m_m_train_tracks": "铁轨世界",
+        "m_m_construction_frame": "施工支架世界"
       }
     },
     "clock_pole": {
@@ -1307,11 +1283,12 @@
       "description": "守时守时一定要守时！",
       "condition": "在以下地点找到并靠近对应世界的时钟：植物世界, 雨之森, 水中植物园（两处）, Sculpture Park, 月光庭院, Monochrome School, Sunrise Road, Pure White Lands, Critter Village",
       "checkbox": {
-        "garden_world_clock_pole": "Garden World",
-        "blue_forest_clock_pole": "雨の森",
-        "botanical_garden_clock_pole_1|botanical_garden_clock_pole_2": "Botanical Garden",
+        "garden_world_clock_pole": "植物世界",
+        "blue_forest_clock_pole": "雨之森",
+        "botanical_garden_clock_pole_1": "outdoors",
+        "botanical_garden_clock_pole_2": "passage",
         "sculpture_park_clock_pole": "Sculpture Park",
-        "twilight_park_clock_pole": "Twilight Park",
+        "twilight_park_clock_pole": "月光庭院",
         "monochrome_school_clock_pole": "Monochrome School",
         "sunrise_road_clock_pole": "Sunrise Road",
         "white_lands_clock_pole": "Pure White Lands",
@@ -1505,10 +1482,11 @@
       "condition": "调查（或抵达） 山顶遗迹 的树木、红细胞海洋（及其赤状态）、Graffiti Maze、和室迷路、苍园、山顶 及 Evergreen Woods。",
       "checkbox": {
         "mountainview_ruins_tree": "Mountaintop Ruins",
-        "tree_of_life_a|tree_of_life_b": "Blood Cell Sea",
+        "tree_of_life_a": "Blood Cell Sea",
+        "tree_of_life_b": "Qliphothic state",
         "graffiti_maze_tree": "Graffiti Maze",
-        "shinto_shrine_tree": "階段とブラザーサン",
-        "scenic_outlook_tree": "目の大樹",
+        "shinto_shrine_tree": "Shinto Shrine",
+        "scenic_outlook_tree": "Scenic Outlook",
         "evergreen_woods_tree": "Evergreen Woods",
         "azure_garden_tree": "Azure Garden"
       }
@@ -2402,7 +2380,10 @@
       "description": "摇啊摇，摇啊摇...",
       "condition": "进入 Oriental Pub 与传送npc连接的六个连接点。",
       "checkbox": {
-        "humanoid_angry|humanoid_crying|humanoid_happy|humanoid_shocked": "スマイルアイス",
+        "humanoid_angry": "Test Facility",
+        "humanoid_crying": "Holiday Hell",
+        "humanoid_happy": "Ice Cream Islands",
+        "humanoid_shocked": "Tribulation Complex",
         "humanoid_green": "Platformer World",
         "humanoid_tired": "Abandoned Grounds"
       }
@@ -3898,8 +3879,10 @@
       "description": "这些扰动的祸害是怪物还是征兆？你是命运的工具还是灾难的见证者？",
       "condition": "锯掉Wooded Lakeside, Kaleidoscope World, Streetlight Docks, Critter Village (Hexagonal Pillar Passage), Pure White Lands的红色怪物",
       "checkbox": {
-        "wooded_lakeside_1_monster|wooded_lakeside_2_monster": "湖のほとり：水路エリア",
-        "hexa_pillar_passage_monster|kaleidscope_world_monster": "六角タイル世界：六角柱通路・水晶",
+        "wooded_lakeside_1_monster": "Wooded Lakeside A",
+        "wooded_lakeside_2_monster": "Wooded Lakeside B",
+        "hexa_pillar_passage_monster": "Critter Village (Hexagonal Pillar Passage)",
+        "kaleidscope_world_monster": "Kaleidoscope World",
         "streetlight_docks_monster": "Streetlight Docks",
         "pure_white_lands_monster": "Pure White Lands"
       }
@@ -4684,7 +4667,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu types 67-70. For any you have already obtained, return to the area where you originally found them.",
+      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",
@@ -5853,8 +5836,8 @@
         "tubes_kondo": "Tubes",
         "purple_crystal": "Memory Graveyard",
         "corrupted_art_gallery_sh_e": "Empty Gallery",
-        "lsd_world": "LSD World (Dynamic)",
-        "kondo_ending_room|kondo_ending_room_2": "Kondo"
+        "lsd_world": "LSD World",
+        "kondo_ending_room|kondo_ending_room_2": "Chaos"
       }
     },
     "rusty_bubble": {
@@ -6986,7 +6969,7 @@
       "condition": "找到所有幼年形态的 Sometsuki。",
       "checkbox": {
         "emerald_square": "Emerald Square",
-        "emerald_square_some": "Emerald Square: Back Alley",
+        "emerald_square_some": "Back Alley",
         "banquet_hall_some": "Banquet Hall"
       }
     },
@@ -7467,11 +7450,7 @@
     "duality_of_mom": {
       "name": "妈妈……",
       "description": "我爱你，请不要伤害我。",
-      "condition": "看到A母亲的温馨和恐怖两种形态",
-      "checkbox": {
-        "mom_normal": "Nursery Room",
-        "mom_scary": "?"
-      }
+      "condition": "看到A母亲的温馨和恐怖两种形态"
     },
     "sacred_cats": {
       "name": "圣猫",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -4667,7 +4667,7 @@
     "2kki_menu_67_70": {
       "name": "Abstract Prism",
       "description": "Prismatic jewels within the colors.",
-      "condition": "Obtain menu themes 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
+      "condition": "Obtain menu types 67-70 in Rainy Sundial, Paraffin Embedding Ruins, Fragmented Station B, and Snow Black. If already obtained, revisit the areas where you found them.",
       "checkbox": {
         "2kki_menu_67": "Rainy Sundial",
         "2kki_menu_68": "Paraffin Embedding Ruins",


### PR DESCRIPTION
Translations are applied ad-hoc where trivial, otherwise only overall structure of checkboxes is maintained.

Also includes modifications to existing badges' conditions, to list their subconditions where appropriate.

cc @Mimigris