### PR TITLE
Fix the RGB Passage and Growing Up badges

### DIFF
--- a/badges/2kki/rgb_passage.json
+++ b/badges/2kki/rgb_passage.json
@@ -1,8 +1,12 @@
 {
   "group": "2_el",
   "bp": 10,
-  "reqType": "tag",
-  "reqString": "rgb_passage",
+  "reqType": "tags",
+  "reqStrings": [
+    "rgb_passage",
+    "rgb_passage_2"
+  ],
+  "reqCount": 1,
   "map": 490,
   "art": "Zolotl",
   "animated": true,

--- a/conditions/2kki/rgb_passage.json
+++ b/conditions/2kki/rgb_passage.json
@@ -1,3 +1,7 @@
 {
-  "map": 490
+  "map": 490,
+  "mapX1": 14,
+  "mapX2": 49,
+  "mapY2": 28,
+  "trigger": "coords"
 }

--- a/conditions/2kki/rgb_passage_2.json
+++ b/conditions/2kki/rgb_passage_2.json
@@ -1,0 +1,8 @@
+{
+  "map": 490,
+  "mapX1": 27,
+  "mapY1": 46,
+  "mapX2": 44,
+  "mapY2": 79,
+  "trigger": "coords"
+}

--- a/conditions/2kki/stretch_const_build.json
+++ b/conditions/2kki/stretch_const_build.json
@@ -5,6 +5,5 @@
   "mapX2": 30,
   "mapY2": 36,
   "switchId": 182,
-  "switchValue": true,
-  "trigger": "coords"
+  "switchValue": true
 }


### PR DESCRIPTION
- Fix an issue where the RGB Passage badge could be obtained in RGB Passage B or in the rooms of the Sugary Depths of Sugar World
- Fix an issue where the Growing Up badge could not be obtained without reloading the connection there