### PR TITLE
Update library_coloring_book.json

### DIFF
--- a/badges/2kki/library_coloring_book.json
+++ b/badges/2kki/library_coloring_book.json
@@ -8,6 +8,7 @@
     "library_coloring_book_3",
     "library_coloring_book_4"
   ],
+  "reqCount": 1,
   "map": 20,
   "art": "Myshfelk",
   "animated": true,

--- a/badges/2kki/library_coloring_book.json
+++ b/badges/2kki/library_coloring_book.json
@@ -8,7 +8,7 @@
     "library_coloring_book_3",
     "library_coloring_book_4"
   ],
-  "reqCount": 1,
+  "reqCount": 3,
   "map": 20,
   "art": "Myshfelk",
   "animated": true,


### PR DESCRIPTION
library_coloring_book_4 is currently inaccessible in the current version, so this change should make it no longer be needed while also keeping it used.