### PR TITLE
Fix some badges

### DIFF
--- a/badges/2kki/sixth_terminal_entrances.json
+++ b/badges/2kki/sixth_terminal_entrances.json
@@ -8,7 +8,6 @@
     "sixth_terminal_entrance_c",
     "sixth_terminal_entrance_d"
   ],
-  "reqCount": 4,
   "map": 1612,
   "secretCondition": true,
   "art": "JSG5",

--- a/conditions/muma/sands_of_time_sands.json
+++ b/conditions/muma/sands_of_time_sands.json
@@ -1,6 +1,5 @@
 {
   "map": 27,
-  "varId": 250,
-  "varValue": 96,
-  "varOp": ">="
+  "switchId": 101,
+  "switchValue": true
 }

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -7558,7 +7558,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7571,7 +7571,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/de.json
+++ b/lang/de.json
@@ -7558,7 +7558,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7571,7 +7571,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -7558,7 +7558,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7571,7 +7571,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/eo.json
+++ b/lang/eo.json
@@ -7557,7 +7557,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7570,7 +7570,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/es.json
+++ b/lang/es.json
@@ -7558,7 +7558,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7571,7 +7571,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -7575,7 +7575,7 @@
     },
     "sands_of_time_sands": {
       "name": "Là où les secondes passent, le sable reste",
-      "condition": "Laisser Muma finir enterrée aux Sands of Time. Si les sables ont atteint le sommet, retournez aux Sands of Time."
+      "condition": "Obtenir le souvenir sablier. Si vous l'avez déjà obtenu, retournez à Sands of Time."
     }
   },
   "genie": {

--- a/lang/it.json
+++ b/lang/it.json
@@ -7558,7 +7558,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7571,7 +7571,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -7590,7 +7590,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Mumaの全身を砂に埋める、すでに砂が積もりきっている場合はSands of Timeにもう一度行く。"
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -7561,7 +7561,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7574,7 +7574,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -7553,7 +7553,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7566,7 +7566,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -7556,7 +7556,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7569,7 +7569,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -7558,7 +7558,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7571,7 +7571,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -7557,7 +7557,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7570,7 +7570,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -7554,7 +7554,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7567,7 +7567,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -7558,7 +7558,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7571,7 +7571,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -7583,7 +7583,7 @@
     "pink_snowscape_globe": {
       "name": "Soft Pink Blizzard",
       "description": "This memory tastes like strawberry popsicle.",
-      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape."
+      "condition": "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."
     },
     "jarred_rose": {
       "name": "Unique Rose",
@@ -7596,7 +7596,7 @@
     },
     "sands_of_time_sands": {
       "name": "Whiling Away the Sandy Seconds",
-      "condition": "Let Muma be fully buried in the Sands of Time. If the sands have already fully risen, simply return to Sands of Time."
+      "condition": "Obtain the Hourglass memory. If you have already unlocked it, return to Sands of Time."
     }
   },
   "genie": {


### PR DESCRIPTION
- Remove unneeded parameter for the Interconnected Network badge
- Change the condition of the Whiling Away the Sandy Seconds to be for getting the memory there (makes more sense + more save-proof)
- Correction of an issue in the Soft Pink Blizzard badge's condition: "Obtain the Snowglobe memory. If you have already unlocked it, return in Pink Snowscape." -> "Obtain the Snowglobe memory. If you have already unlocked it, return to Pink Snowscape."