### PR TITLE
Add a missing condition to the Captivating Smile badge

### DIFF
--- a/badges/2kki/green_haired_faerie_sunken.json
+++ b/badges/2kki/green_haired_faerie_sunken.json
@@ -4,7 +4,8 @@
   "reqType": "tags",
   "reqStrings": [
     "green_haired_faerie",
-    "green_haired_sunken"
+    "green_haired_sunken",
+    "green_haired_strawberry"
   ],
   "map": 3124,
   "secretMap": true,

--- a/badges/2kki/star_technicolor_towers.json
+++ b/badges/2kki/star_technicolor_towers.json
@@ -4,6 +4,8 @@
   "reqType": "tag",
   "reqString": "star_technicolor_towers",
   "map": 3130,
+  "mapX": 13,
+  "mapY": 25,
   "secretCondition": true,
   "art": "nicotee",
   "batch": 150

--- a/conditions/2kki/green_haired_strawberry.json
+++ b/conditions/2kki/green_haired_strawberry.json
@@ -1,0 +1,9 @@
+{
+  "map": 3505,
+  "mapX1": 48,
+  "mapY1": 167,
+  "mapX2": 67,
+  "mapY2": 179,
+  "trigger": "eventAction",
+  "value": "85"
+}

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -6029,10 +6029,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6717,7 +6718,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/de.json
+++ b/lang/de.json
@@ -6029,10 +6029,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6717,7 +6718,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6029,10 +6029,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6717,7 +6718,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/eo.json
+++ b/lang/eo.json
@@ -6028,10 +6028,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6716,7 +6717,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/es.json
+++ b/lang/es.json
@@ -6029,10 +6029,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6717,7 +6718,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -6033,10 +6033,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Sourire captivant",
-      "condition": "Trouver la fille aux cheveux verts foncés au Faerie Hollow et interagir avec elle au Sunken Spore Sea",
+      "condition": "Trouver la fille aux cheveux verts foncés au Faerie Hollow, aux Strawberry Outskirts et interagir avec elle au Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Trouver la fille aux cheveux verts foncés au Faerie Hollow",
-        "green_haired_sunken": "interagir avec elle au Sunken Spore Sea"
+        "green_haired_sunken": "interagir avec elle au Sunken Spore Sea",
+        "green_haired_strawberry": "aux Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6721,7 +6722,7 @@
     "glass_shard_path": {
       "name": "Vitres colorées",
       "description": "Pour les amoureux de la pluie et du verre",
-      "condition": "Visiter le Glass Shard Path"
+      "condition": "Visiter le Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Jardin céleste d'antan",

--- a/lang/it.json
+++ b/lang/it.json
@@ -6029,10 +6029,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6717,7 +6718,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -6048,10 +6048,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -6032,10 +6032,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6720,7 +6721,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -6024,10 +6024,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6712,7 +6713,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -6028,10 +6028,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6716,7 +6717,7 @@
     "glass_shard_path": {
       "name": "Vidro Colorguacheado",
       "description": "Para os amantes da chuva e do vidro",
-      "condition": "Visite  o Glass Shard Path"
+      "condition": "Visite  o Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Jardim do Céu Antigo",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -6029,10 +6029,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6717,7 +6718,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -6028,10 +6028,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6716,7 +6717,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -6025,10 +6025,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6713,7 +6714,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -6029,10 +6029,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6717,7 +6718,7 @@
     "glass_shard_path": {
       "name": "Colorwashed Glass",
       "description": "For lovers of rain and glass",
-      "condition": "Visit Glass Shard Path"
+      "condition": "Visit Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "Ancient Sky Garden",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -6046,10 +6046,11 @@
     },
     "green_haired_faerie_sunken": {
       "name": "Captivating Smile",
-      "condition": "Find the dark green-haired woman in Faerie Hollow and interact with her in the Sunken Spore Sea",
+      "condition": "Find the dark green-haired woman in Faerie Hollow, in Strawberry Outskirts, and interact with her in the Sunken Spore Sea",
       "checkbox": {
         "green_haired_faerie": "Find the dark green-haired woman in Faerie Hollow",
-        "green_haired_sunken": "interact with her in the Sunken Spore Sea"
+        "green_haired_sunken": "interact with her in the Sunken Spore Sea",
+        "green_haired_strawberry": "in Strawberry Outskirts"
       }
     },
     "princess_crescent_tile_world": {
@@ -6734,7 +6735,7 @@
     "glass_shard_path": {
       "name": "褪色玻璃",
       "description": "献给喜欢雨和玻璃的玩家",
-      "condition": "抵达Glass Shard Path"
+      "condition": "抵达Glass Shards Path"
     },
     "outside_primeval_edifice": {
       "name": "古代空中花园",


### PR DESCRIPTION
Fix Glass Shards Path being incorrectly written as Glass Shard Path