### PR TITLE
Updated translations

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3746,7 +3746,7 @@
       "condition": "Buy water from the cactus vendor in Cactus Desert"
     },
     "haniwa_lonely_home": {
-      "name": "Haniwa and the Girl",
+      "name": "Haniwa Girl",
       "condition": "Equip the Haniwa effect and interact with the orange-haired girl in Lonely Home"
     },
     "legacy_nexus": {
@@ -4268,7 +4268,7 @@
     "diary_graveyard_repent": {
       "name": "Someone's Diary",
       "description": "I miss you...",
-      "condition": "Read the diary in a place that can be reached from a small room in the Graveyard of Repentance"
+      "condition": "Read the diary in the Prologue subarea of Graveyard of Repentance"
     },
     "cake_slime_village": {
       "name": "Slimy Sweets",
@@ -4399,7 +4399,7 @@
     "red_haired_girl_thumbtack": {
       "name": "Broken Solitude",
       "description": "One thumbtack away...",
-      "condition": "Interact with the red-haired girl in the small black room in Thumbtack World"
+      "condition": "Interact with Beniko in Thumbtack World"
     },
     "girl_colorful_rose_garden": {
       "name": "Colorful Girl",


### PR DESCRIPTION
Updated some of these translations based on the Japanese ones, as well as to match the terminology used by the wiki. E.g. the orange-haired girl is named Haniwa-musume, meaning "Haniwa Girl"