### PR TITLE
Adjust badges

### DIFF
--- a/badges/unconscious/adobe_town.json
+++ b/badges/unconscious/adobe_town.json
@@ -6,5 +6,5 @@
   "map": 1035,
   "art": "Komaki",
   "animated": true,
-  "batch": 187
+  "batch": 186
 }

--- a/badges/unconscious/room_3_a_corrupted_school.json
+++ b/badges/unconscious/room_3_a_corrupted_school.json
@@ -8,5 +8,6 @@
   "secretCondition": true,
   "art": "daffodil",
   "animated": true,
-  "batch": 186
+  "batch": 255,
+  "dev": true
 }

--- a/badges/unevendream/menu_8_overgrown_stairs.json
+++ b/badges/unevendream/menu_8_overgrown_stairs.json
@@ -4,6 +4,8 @@
   "reqType": "tag",
   "reqString": "menu_8_overgrown_stairs",
   "map": 556,
+  "mapX": 20,
+  "mapY": 20,
   "art": "Komaki",
   "animated": true,
   "batch": 186


### PR DESCRIPTION
- Fix the location display of the menu theme 8 badge
- Replace the Corrupted School badge by the Adobe Town badge (the Corrupted School is impossible to track in its current state, as you do not reach the variant of the room, the roll is done inside the event interaction, and no reliable code in it could be tracked; may have to see if the trigger could be included in the map itself as part of a future update, but for now, I'm disabling it)