### PR TITLE
change okuri ending badges to picture events

### DIFF
--- a/conditions/okuri/first_anniversary.json
+++ b/conditions/okuri/first_anniversary.json
@@ -1,5 +1,5 @@
 {
   "map": 9,
-  "varId": 1,
-  "varValue": 5
+  "trigger": "picture",
+  "value": "pic_ED2"
 }

--- a/conditions/okuri/ordinary_day.json
+++ b/conditions/okuri/ordinary_day.json
@@ -1,5 +1,5 @@
 {
   "map": 8,
-  "varId": 4,
-  "varValue": 5
+  "trigger": "picture",
+  "value": "pic_ED1"
 }


### PR DESCRIPTION
the `first_anniversary` badge is unreliable, i am unable to get it although other players have, someone mentioned having to mess around with reconnecting to get it
the server hasn't restarted yet to test `ordinary_day`