### PR TITLE
Fix location for Virulent Remedies

### DIFF
--- a/badges/2kki/visit_hemlock_lab.json
+++ b/badges/2kki/visit_hemlock_lab.json
@@ -5,6 +5,8 @@
   "bp": 20,
   "group": "2_el",
   "map": 3368,
+  "mapX": 121.
+  "mapY": 314,
   "reqString": "visit_hemlock_lab",
   "reqType": "tag",
   "secretCondition": true

--- a/badges/2kki/visit_hemlock_lab.json
+++ b/badges/2kki/visit_hemlock_lab.json
@@ -5,7 +5,7 @@
   "bp": 20,
   "group": "2_el",
   "map": 3368,
-  "mapX": 121.
+  "mapX": 121,
   "mapY": 314,
   "reqString": "visit_hemlock_lab",
   "reqType": "tag",


### PR DESCRIPTION
Add mapX and mapY values to the badge file
