### PR TITLE
Make cold_a_effect obtainable after seeing the event

### DIFF
--- a/badges/cold/cold_a_effect.json
+++ b/badges/cold/cold_a_effect.json
@@ -4,6 +4,7 @@
   "batch": 212,
   "bp": 15,
   "map": 126,
-  "reqString": "cold_a_effect",
-  "reqType": "tag"
+  "reqStrings": ["cold_a_effect", "cold_a_effect_after_event"],
+  "reqCount": 1,
+  "reqType": "tags"
 }

--- a/conditions/cold/cold_a_effect_after_event.json
+++ b/conditions/cold/cold_a_effect_after_event.json
@@ -1,0 +1,5 @@
+{
+  "map": 131,
+  "switchId": 270,
+  "switchValue": true
+}


### PR DESCRIPTION
The event specified in `conditions/cold_a_effect` can only be seen once per save file. It is on a separate map that is not reachable once the effect is unlocked. This PR adds an extra condition that is triggered once the player goes as far as it's possible to go with the effect unlocked.