### PR TITLE
Fix "Binary Truth" location

### DIFF
--- a/badges/2kki/city_of_liars_01_npc.json
+++ b/badges/2kki/city_of_liars_01_npc.json
@@ -4,6 +4,8 @@
   "reqType": "tag",
   "reqString": "city_of_liars_01_npc",
   "map": 1308,
+  "mapX": 42,
+  "mapY": 52,
   "art": "Paraverdant",
   "animated": true,
   "batch": 214


### PR DESCRIPTION
add mapX and mapY values to badge file to correct the incorrect location shown on the badge