### PR TITLE
Make more once-per-save-file event badges obtainable after seeing the events

### DIFF
--- a/badges/loveyou/ly_discomfort_bath_corpse.json
+++ b/badges/loveyou/ly_discomfort_bath_corpse.json
@@ -1,7 +1,8 @@
 {
   "bp": 20,
-  "reqType": "tag",
-  "reqString": "ly_discomfort_bath_corpse",
+  "reqType": "tags",
+  "reqStrings": ["ly_discomfort_bath_corpse", "ly_discomfort_bath_corpse_after"],
+  "reqCount": 1,
   "map": 31,
   "art": "Anju",
   "animated": true,

--- a/badges/loveyou/visit_night_field.json
+++ b/badges/loveyou/visit_night_field.json
@@ -1,7 +1,8 @@
 {
   "bp": 10,
-  "reqType": "tag",
-  "reqString": "visit_night_field",
+  "reqType": "tags",
+  "reqStrings": ["visit_night_field", "visit_night_field_after_event"],
+  "reqCount": 1,
   "map": 94,
   "art": "Masky1977",
   "animated": true,

--- a/conditions/loveyou/ly_discomfort_bath_corpse_after.json
+++ b/conditions/loveyou/ly_discomfort_bath_corpse_after.json
@@ -1,0 +1,5 @@
+{
+  "map": 31,
+  "switchId": 33,
+  "switchValue": true
+}

--- a/conditions/loveyou/visit_night_field_after_event.json
+++ b/conditions/loveyou/visit_night_field_after_event.json
@@ -1,0 +1,5 @@
+{
+  "map": 92,
+  "switchId": 215,
+  "switchValue": true
+}

--- a/conditions/loveyou/visit_night_field_after_event.json
+++ b/conditions/loveyou/visit_night_field_after_event.json
@@ -1,5 +1,10 @@
 {
   "map": 92,
+  "mapX1": 96,
+  "mapY1": 8,
+  "mapX2": 102,
+  "mapY2": 14,
   "switchId": 215,
-  "switchValue": true
+  "switchValue": true,
+  "trigger": "coords"
 }


### PR DESCRIPTION
Existing conditions for both of these depended on maps/events that become permanently inaccessible once certain events are seen.

> Completing the event sets switch 215 which blocks off Night Field. There appears to be no way to turn this switch off once it's set.

> Similarly to visit_night_field, seeing the event sets switch 33 which removes the event NPC from the map and appears to have no way of being turned off.