### PR TITLE
Fix location for "Friend-shaped"

### DIFF
--- a/badges/yume/yume_fatten_effect.json
+++ b/badges/yume/yume_fatten_effect.json
@@ -3,6 +3,8 @@
   "reqType": "tag",
   "reqString": "yume_fatten_effect",
   "map": 111,
+  "mapX": 94,
+  "mapY": 7,
   "art": "HenryAutumn",
   "batch": 215
 }


### PR DESCRIPTION
Add mapX and mapY values to the badge file to fix the incorrect location being shown