### PR TITLE
Make muma_realm_orb_empty work (also on 100% save data)

### DIFF
--- a/badges/muma/muma_realm_orb_empty.json
+++ b/badges/muma/muma_realm_orb_empty.json
@@ -1,7 +1,8 @@
 {
   "bp": 25,
-  "reqType": "tag",
-  "reqString": "muma_realm_orb_empty",
+  "reqType": "tags",
+  "reqStrings": ["muma_realm_orb_empty", "realm_of_the_orb_snake_a"],
+  "reqCount": 1,
   "map": 9,
   "art": "Aurora",
   "animated": true,

--- a/conditions/muma/muma_realm_orb_empty.json
+++ b/conditions/muma/muma_realm_orb_empty.json
@@ -1,7 +1,5 @@
 {
   "map": 9,
-  "switchId": 217,
-  "switchValue": true,
-  "trigger": "eventAction",
+  "trigger": "event",
   "value": "6"
 }


### PR DESCRIPTION
realm_of_the_orb_snake_a is reused because the condition for both is the same (have the empty already, enter the map prior to the empty room).