### PR TITLE
Update capitalization of Tapir-san

### DIFF
--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/eo.json
+++ b/lang/eo.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendentif de souvenirs",
       "description": "« Je » suis là.",
-      "condition": "Rencontrer Urotsuki ou trouver un terrain la ressemblant dans Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, et Spear Tribe World (Zone des Pierres Moussues)",
+      "condition": "Rencontrer Urotsuki ou trouver un terrain la ressemblant dans Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, et Spear Tribe World (Zone des Pierres Moussues)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2613,8 +2613,8 @@
     },
     "tapir_san_tapir": {
       "name": "Mangeur de rêves",
-      "description": "Rendre visite à Tapir-San",
-      "condition": "Voir Tapir-San dans Tapir-San's Place"
+      "description": "Rendre visite à Tapir-san",
+      "condition": "Voir Tapir-san dans Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Se reflétant paisiblement dans l'eau",

--- a/lang/id.json
+++ b/lang/id.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1680,10 +1680,10 @@
     "urotsuki_pendant": {
       "name": "추억의 펜던트",
       "description": "\"나\" 는 여기 있어.",
-      "condition": "Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, Spear Tribe World (Overgrown Stone Area)에서 우로츠키 혹은, 그녀와 비슷한 지형과 만나기",
+      "condition": "Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, Spear Tribe World (Overgrown Stone Area)에서 우로츠키 혹은, 그녀와 비슷한 지형과 만나기",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,7 +2607,7 @@
     "tapir_san_tapir": {
       "name": "꿈을 먹는 자",
       "description": "타피르 씨를 찾아가 보라",
-      "condition": "Tapir-San's Place에서 Tapir-san(맥씨) NPC를 찾아내기"
+      "condition": "Tapir-san's Place에서 Tapir-san(맥씨) NPC를 찾아내기"
     },
     "fossil_lake_creature": {
       "name": "미동이 없는 물 속의 반영",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1680,10 +1680,10 @@
     "urotsuki_pendant": {
       "name": "Pingente de Memórias",
       "description": "\"Eu\" estou aqui.",
-      "condition": "Encontre Urotsuki ou encontre terreno similar a ela em Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley e Spear Tribe World (Overgrown Stone Area).",
+      "condition": "Encontre Urotsuki ou encontre terreno similar a ela em Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley e Spear Tribe World (Overgrown Stone Area).",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2606,8 +2606,8 @@
     },
     "tapir_san_tapir": {
       "name": "Devorador de Sonhos",
-      "description": "Faça uma visita ao Tapir-San",
-      "condition": "Veja o Tapir-San no Tapir-San's Place"
+      "description": "Faça uma visita ao Tapir-san",
+      "condition": "Veja o Tapir-san no Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Refletindo na água de forma passiva",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1680,10 +1680,10 @@
     "urotsuki_pendant": {
       "name": "Кулон на память",
       "description": "\"Я\" здесь.",
-      "condition": "Встретьесь с Уроцуки или найдите элементы местности похожие на неё в Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, и Spear Tribe World (Overgrown Stone Area).",
+      "condition": "Встретьесь с Уроцуки или найдите элементы местности похожие на неё в Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, и Spear Tribe World (Overgrown Stone Area).",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,7 +2607,7 @@
     "tapir_san_tapir": {
       "name": "Пожиратель снов",
       "description": "Посетите Тапир-сана.",
-      "condition": "Увидьтесь с Тапир-саном в Tapir-San's Place."
+      "condition": "Увидьтесь с Тапир-саном в Tapir-san's Place."
     },
     "fossil_lake_creature": {
       "name": "Пассивное отражение в воде",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -1678,10 +1678,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2604,8 +2604,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Pendant of Memories",
       "description": "\"I\" am here.",
-      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Encounter Urotsuki or find terrain similar to her in Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, and Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Dream Eater",
-      "description": "Pay a visit to Tapir-San",
-      "condition": "See Tapir-San in Tapir-San's Place"
+      "description": "Pay a visit to Tapir-san",
+      "condition": "See Tapir-san in Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Reflecting in Water Passively",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "Mặt dây chuyền hoài niệm",
       "description": "\"Tôi\" ở đây.",
-      "condition": "Gặp Urotsuki hoặc tìm địa hình trong giống cô ấy ở Atlantis, Tapir-San's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, và Spear Tribe World (Overgrown Stone Area)",
+      "condition": "Gặp Urotsuki hoặc tìm địa hình trong giống cô ấy ở Atlantis, Tapir-san's Place, Red Brick Maze (Giant Cloning Room), Urotsuki's Dream Apartments (Bleak Future), Closet Pinwheel Path, Red Sky Cliff, Despair Road, Head World, Static Noise Hell, Colorless Valley, và Spear Tribe World (Overgrown Stone Area)",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Red Brick Maze (Giant Cloning Room)",
         "uro_bleak_future": "Urotsuki's Dream Apartments (Bleak Future)",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2607,8 +2607,8 @@
     },
     "tapir_san_tapir": {
       "name": "Kẻ ăn giấc mơ",
-      "description": "Đến thăm Tapir-San",
-      "condition": "Gặp Tapir-San trong Tapir-San's Place"
+      "description": "Đến thăm Tapir-san",
+      "condition": "Gặp Tapir-san trong Tapir-san's Place"
     },
     "fossil_lake_creature": {
       "name": "Dửng dưng soi bóng",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1681,10 +1681,10 @@
     "urotsuki_pendant": {
       "name": "记忆吊坠",
       "description": "\"我\" 在这里。",
-      "condition": "在以下地点找到Urotsuki或其类似物：Atlantis、Tapir-San's Place、Giant Cloning Room、Bleak Future、Closet Pinwheel Path，Red Sky Cliff、Despair Road，Head World、Static Noise Hell、Colorless Valley、Spear Tribe World。",
+      "condition": "在以下地点找到Urotsuki或其类似物：Atlantis、Tapir-san's Place、Giant Cloning Room、Bleak Future、Closet Pinwheel Path，Red Sky Cliff、Despair Road，Head World、Static Noise Hell、Colorless Valley、Spear Tribe World。",
       "checkbox": {
         "uro_atlantis": "Atlantis",
-        "uro_tapir_place": "Tapir-San's Place",
+        "uro_tapir_place": "Tapir-san's Place",
         "uro_cloning_room": "Giant Cloning Room",
         "uro_bleak_future": "Bleak Future",
         "uro_pinwheel_path": "Closet Pinwheel Path",
@@ -2614,7 +2614,7 @@
     "tapir_san_tapir": {
       "name": "捕梦者",
       "description": "拜访貘先生。",
-      "condition": "见到Tapir-San's Place中的貘先生。"
+      "condition": "见到Tapir-san's Place中的貘先生。"
     },
     "fossil_lake_creature": {
       "name": "倒影",


### PR DESCRIPTION
The wiki text and page titles have been updated to use lowercase "-san", consistent with other uses