### PR TITLE
Add map coordinates for crimson_drains_dragon location display

### DIFF
--- a/badges/2kki/crimson_drains_dragon.json
+++ b/badges/2kki/crimson_drains_dragon.json
@@ -4,6 +4,8 @@
   "reqType": "tag",
   "reqString": "crimson_drains_dragon",
   "map": 4088,
+  "mapX": 283,
+  "mapY": 252,
   "secretCondition": true,
   "art": "Michi",
   "batch": 219


### PR DESCRIPTION
fix "Vermilion Hydra" badge tooltip showing Watching Forest.