### PR TITLE
Make more once-per-save-file event badges obtainable after seeing the events

### DIFF
--- a/badges/loveyou/ly_palliative_ward.json
+++ b/badges/loveyou/ly_palliative_ward.json
@@ -1,7 +1,8 @@
 {
   "bp": 10,
-  "reqType": "tag",
-  "reqString": "ly_palliative_ward",
+  "reqType": "tags",
+  "reqStrings": ["ly_palliative_ward", "ly_palliative_ward_after_event"],
+  "reqCount": 1,
   "map": 96,
   "secretCondition": true,
   "art": "Ticks",

--- a/badges/loveyou/ly_victim_effect.json
+++ b/badges/loveyou/ly_victim_effect.json
@@ -1,7 +1,8 @@
 {
   "bp": 10,
-  "reqType": "tag",
-  "reqString": "ly_victim_effect",
+  "reqType": "tags",
+  "reqStrings": ["ly_victim_effect", "ly_victim_effect_after_event"],
+  "reqCount": 1,
   "map": 65,
   "art": "systemaciel",
   "batch": 221

--- a/conditions/loveyou/ly_palliative_ward_after_event.json
+++ b/conditions/loveyou/ly_palliative_ward_after_event.json
@@ -1,0 +1,5 @@
+{
+  "map": 126,
+  "switchId": 215,
+  "switchValue": true
+}

--- a/conditions/loveyou/ly_victim_effect_after_event.json
+++ b/conditions/loveyou/ly_victim_effect_after_event.json
@@ -1,0 +1,5 @@
+{
+  "map": 12,
+  "switchId": 45,
+  "switchValue": true
+}

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/de.json
+++ b/lang/de.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/en.json
+++ b/lang/en.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/eo.json
+++ b/lang/eo.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/es.json
+++ b/lang/es.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -13706,7 +13706,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/id.json
+++ b/lang/id.json
@@ -13634,7 +13634,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/it.json
+++ b/lang/it.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -13724,7 +13724,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -13699,7 +13699,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -13698,7 +13698,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -13699,7 +13699,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -13707,7 +13707,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -13710,7 +13710,7 @@
     "ly_victim_effect": {
       "name": "You Smell So Red",
       "description": "What did you do?",
-      "condition": "Obtain the Victim effect. If you have already unlocked it, return where it can be found in Sacrificial Ground."
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -13712,7 +13712,7 @@
     "ly_victim_effect": {
       "name": "你一身血腥味",
       "description": "你干了什么？",
-      "condition": "获得效果Victim。若已解锁，请返回Sacrificial Ground获得该效果处。"
+      "condition": "Obtain the Victim effect. If you have already unlocked it, return to -30."
     },
     "ly_visit_sunset_skyscrapers": {
       "name": "ly_construct",


### PR DESCRIPTION
ly_victim_effect: obtaining the effect locks you out of the location the effect is in (see map0012 ev0004/ev0005 page 2). As a workaround the closest place you can still go to is used instead.

ly_palliative_ward: the map the event is in is unreachable once the event is done: waking up unsets switch 200 needed for the event map to be accessible; doing the event sets switch 215 which blocks the way to the only place switch 200 can be turned on from (map0095 onsen).