### PR TITLE
Make ly_sansara_effect unlockable by equipping the effect

### DIFF
--- a/badges/loveyou/ly_sansara_effect.json
+++ b/badges/loveyou/ly_sansara_effect.json
@@ -1,7 +1,8 @@
 {
   "bp": 15,
-  "reqType": "tag",
-  "reqString": "ly_sansara_effect",
+  "reqType": "tags",
+  "reqStrings": ["ly_sansara_effect", "ly_sansara_effect_equip"],
+  "reqCount": 1,
   "map": 126,
   "art": "SamsungFridg",
   "batch": 223

--- a/conditions/loveyou/ly_sansara_effect_equip.json
+++ b/conditions/loveyou/ly_sansara_effect_equip.json
@@ -1,0 +1,9 @@
+{
+  "map": 126,
+  "mapX1": 24,
+  "mapY1": 122,
+  "mapX2": 63,
+  "mapY2": 136,
+  "varId": 14,
+  "varValue": 6
+}


### PR DESCRIPTION
#1344:
> As of the current version (0.03b) most of the effect switches get permanently unset when any effect is unequipped (see EV0016 dequip effect), making it impossible to get the badges with the current switch conditions on a save file with these effects already unlocked.