### PR TITLE
Make ami_permian_cutscene obtainable after seeing the event

### DIFF
--- a/badges/amillusion/ami_permian_cutscene.json
+++ b/badges/amillusion/ami_permian_cutscene.json
@@ -2,7 +2,7 @@
   "bp": 15,
   "reqType": "tag",
   "reqString": "ami_permian_cutscene",
-  "map": 313,
+  "map": 274,
   "art": "Snoocola",
   "batch": 223
 }

--- a/conditions/amillusion/ami_permian_cutscene.json
+++ b/conditions/amillusion/ami_permian_cutscene.json
@@ -1,3 +1,5 @@
 {
-  "map": 313
+  "map": 274,
+  "switchId": 426,
+  "switchValue": true
 }


### PR DESCRIPTION
Switch 426 prevents the minigame (and by extension the event) from being done again on the same file; it's also set directly after the cutscene so it's fine to use it as the only condition.

(I've tested both cases (fresh and post-event).)