### PR TITLE
Update donut_kaleidoscope.json

### DIFF
--- a/conditions/2kki/donut_kaleidoscope.json
+++ b/conditions/2kki/donut_kaleidoscope.json
@@ -1,8 +1,8 @@
 {
   "map": 1826,
   "mapX1": 1,
-  "mapY1": 130,
+  "mapY1": 200,
   "mapX2": 33,
-  "mapY2": 155,
+  "mapY2": 255,
   "trigger": "coords"
 }


### PR DESCRIPTION
Updating coordinates to Kaleidascope Donut to prevent getting it and Dolphin Drinker badges at the same time. Both on the same map.