### PR TITLE
Update blossom_board_npc_reactions.json

### DIFF
--- a/badges/2kki/blossom_board_npc_reactions.json
+++ b/badges/2kki/blossom_board_npc_reactions.json
@@ -8,6 +8,8 @@
     "blossom_board_npc_reaction_3"
   ],
   "map": 3503,
+  "mapX": 194,
+  "mapY": 18,
   "art": "AduriteStar",
   "animated": true,
   "batch": 226


### PR DESCRIPTION
Fixing the location of this badge to accurately show as Blossom Boardwalk NPC room and not Windy Tunnels. Both share the same ID.