### PR TITLE
Fix issues with muma_broken_passageway_cat

### DIFF
--- a/conditions/muma/muma_broken_passageway_cat.json
+++ b/conditions/muma/muma_broken_passageway_cat.json
@@ -1,9 +1,8 @@
 {
-  "map": 1562,
+  "map": 162,
   "mapX1": 53,
   "mapY1": 162,
   "mapX2": 60,
   "mapY2": 169,
-  "trigger": "eventAction",
-  "value": "731"
+  "trigger": "coords"
 }


### PR DESCRIPTION
The map ID had a typo; the event referenced in the condition doesn't appear reachable and has no commands so it wouldn't sync.

I have not tested this.