### PR TITLE
Removed Restored Character World from zalgo_appearance conditions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2449,12 +2449,11 @@
     },
     "zalgo_appearance": {
       "name": "Z̴̜̬̈́͐̒̄͑̃͛̄̊̕͝Ạ̶̭̮̰̯̱̠̠͖̜̲̯̈́̃͌͑̚͘ͅL̵̡̡̡͓͚̖̗̙̹̲̻̝͚̒͒͌G̷̝̜̦̱̠̝̮̲̺̝̽̓͜Ŏ̷͈́̔̚̕̕͝",
-      "condition": "Find Zalgo in the Magnet Room, Train Tracks, the Atelier, and Restored Character World",
+      "condition": "Find Zalgo in the Magnet Room, Train Tracks, and the Atelier",
       "checkbox": {
         "zalgo_magnet_room": "Magnet Room",
         "zalgo_train_tracks": "Train Tracks",
-        "zalgo_atelier": "Atelier",
-        "zalgo_character": "Restored Character World"
+        "zalgo_atelier": "Atelier"
       }
     },
     "cyclop_holiday_hell": {
@@ -5688,7 +5687,7 @@
     "twintails_effect": {
       "name": "The Wolf of Infinite Dream",
       "description": "Essence of twintails",
-      "condition": "Obtain the Twintails effect. If you have already unlocked it, return where it can be found at The Deciding Street."
+      "condition": "Obtain the Twintails effect. If you have already unlocked it, return where it can be found at the Deciding Street."
     },
     "quarter_flats": {
       "name": "Ceramic Islands",


### PR DESCRIPTION
Restored Character World was removed in a recent update. Also, removed the capital "The" in "the Deciding Street"